### PR TITLE
Add CEA Busiest Collections tab to Log Analyzer

### DIFF
--- a/migration/mongosync_insights/LOG_ANALYZER.md
+++ b/migration/mongosync_insights/LOG_ANALYZER.md
@@ -63,6 +63,7 @@ After parsing, the results page shows one or more tabs:
 | **Mongosync Metrics** | Prometheus metrics found | Charts from `mongosync_metrics.json` (OTel/Prometheus exposition in log lines) |
 | **Mongosync Options** | Log lines found | Version info, startup options, hidden flags, `/api/v1/start` request body |
 | **Collections and Partitions** | Log lines found | Natural-order collections and per-collection partition tables |
+| **CEA Busiest Collections** | CEA CRUD statistics found in log | Per-namespace CEA write rankings, time-series chart, and workload warnings |
 | **Errors and Warnings** | Log lines found | Pattern-matched errors with optional recommendations |
 | **Log Viewer** | Log lines found | Tail view and full-text search over indexed log lines |
 
@@ -97,6 +98,16 @@ Read-only tables for:
 - **Collection Partitions** — per-collection partition progress tables (searchable, exportable as Markdown)
 
 ![Collections and Partitions tab](images/mongosync_logs_collections_partitions.png)
+
+### CEA Busiest Collections
+
+Shown when the uploaded log contains mongosync **CEA (change event application)** CRUD statistics.
+
+- **Time-series chart** — top namespaces by write volume per 10-second interval
+- **Namespace write activity table** — cumulative write ops by type (insert, update, delete, replace, etc.), sortable and searchable, with **Copy as Markdown**
+- **CEA workload warnings** — hot-document and `$out` aggregation warnings with spread disparity; **View in Log Viewer** jumps to that namespace
+
+> **Note:** Mongosync logs only the **top 20** busiest collections per 10-second interval. Totals are approximate and may under-count namespaces that were never in that window. The tab requires log segments that include CEA at default `info` verbosity.
 
 ### Errors and Warnings
 

--- a/migration/mongosync_insights/LOG_VERBOSITY.md
+++ b/migration/mongosync_insights/LOG_VERBOSITY.md
@@ -63,6 +63,7 @@ The table below lists every chart and panel in Mongosync Insights, the minimum v
 | Events Rate per Second | `info` (default) | `"Replication progress"` → `eventApplicationRatePerSecond` |
 | CEA Source Read — avg / max / ops | `info` (default) | `"Operation duration stats"` → `CEASourceRead` |
 | CEA Destination Write — avg / max / ops | `info` (default) | `"Operation duration stats"` → `CEADestinationWrite` |
+| CEA Busiest Collections (tab) | `info` (default) | `"Recent CRUD change event statistics."` → `recentCRUDStatistics.busiestCollections`; warn lines with `recentCRUDStatistics` for hot-document / `$out` workload |
 
 ### Indexes Metrics
 

--- a/migration/mongosync_insights/lib/busiest_collections.py
+++ b/migration/mongosync_insights/lib/busiest_collections.py
@@ -1,0 +1,262 @@
+"""Parse mongosync CEA CRUD statistics for busiest-collections analysis."""
+import json
+from collections import defaultdict
+from datetime import datetime
+
+import plotly.graph_objects as go
+from plotly.utils import PlotlyJSONEncoder
+
+from .plot_theme import apply_mi_theme
+
+CRUD_STATS_MESSAGE = "Recent CRUD change event statistics."
+LOW_CEA_PARALLELIZATION_PREFIX = (
+    "The level of CEA parallelization for this collection is low"
+)
+BUSY_AGG_OUT_PREFIX = "Most source writes appear to be from $out aggregations"
+
+INTERVAL_SECS = 10
+TOP_N_PER_INTERVAL = 20
+CHART_TOP_N = 10
+DEFAULT_EVENT_TYPES = ("delete", "insert", "replace", "update")
+
+
+def update_in_cea_phase(cea_phase, canonical_phase):
+    """Return updated CEA phase flag from a canonical migration phase name."""
+    if canonical_phase == "change event application":
+        return True
+    if canonical_phase == "commit handler called":
+        return False
+    return cea_phase
+
+
+class _NamespaceStats:
+    __slots__ = (
+        "total_events",
+        "total_events_per_type",
+        "warning_count",
+        "max_spread_disparity",
+    )
+
+    def __init__(self):
+        self.total_events = 0
+        self.total_events_per_type = defaultdict(int)
+        self.warning_count = 0
+        self.max_spread_disparity = None
+
+    def add_collection(self, namespace, total_events, events_per_type):
+        if not namespace:
+            return
+        self.total_events += int(total_events or 0)
+        for op_type, count in (events_per_type or {}).items():
+            self.total_events_per_type[op_type] += int(count or 0)
+
+    def add_warning(self, spread_disparity):
+        self.warning_count += 1
+        if spread_disparity is not None:
+            if (
+                self.max_spread_disparity is None
+                or spread_disparity > self.max_spread_disparity
+            ):
+                self.max_spread_disparity = spread_disparity
+
+
+class BusiestCollectionsAccumulator:
+    """Accumulate CEA busiest-collection statistics from mongosync log lines."""
+
+    def __init__(self):
+        self._namespaces = {}
+        self._interval_snapshots = []
+        self._warnings = []
+        self._intervals_processed = 0
+        self._skipped_outside_cea = 0
+        self._event_types = set(DEFAULT_EVENT_TYPES)
+
+    def _namespace_stats(self, namespace):
+        if namespace not in self._namespaces:
+            self._namespaces[namespace] = _NamespaceStats()
+        return self._namespaces[namespace]
+
+    def ingest_line(self, json_obj, *, in_cea_phase):
+        message = json_obj.get("message") or ""
+        stats = json_obj.get("recentCRUDStatistics")
+        if not stats:
+            return
+
+        if message == CRUD_STATS_MESSAGE:
+            if not in_cea_phase:
+                self._skipped_outside_cea += 1
+                return
+            self._ingest_info_line(json_obj, stats)
+            return
+
+        if not in_cea_phase:
+            self._skipped_outside_cea += 1
+            return
+
+        if self._is_warning_message(message) and stats.get("namespace"):
+            self._ingest_warning_line(json_obj, stats, message)
+
+    def _is_warning_message(self, message):
+        return (
+            message.startswith(LOW_CEA_PARALLELIZATION_PREFIX)
+            or message.startswith(BUSY_AGG_OUT_PREFIX)
+        )
+
+    def _record_event_types(self, events_per_type):
+        for op_type in (events_per_type or {}):
+            self._event_types.add(op_type)
+
+    def _ingest_info_line(self, json_obj, stats):
+        timestamp = json_obj.get("time") or ""
+        busiest = stats.get("busiestCollections") or []
+        if not busiest:
+            return
+
+        interval_counts = {}
+        for collection in busiest:
+            namespace = collection.get("namespace")
+            total_events = int(collection.get("totalEvents") or 0)
+            events_per_type = collection.get("totalEventsPerType") or {}
+            if not namespace:
+                continue
+            self._record_event_types(events_per_type)
+            ns_stats = self._namespace_stats(namespace)
+            ns_stats.add_collection(namespace, total_events, events_per_type)
+            interval_counts[namespace] = (
+                interval_counts.get(namespace, 0) + total_events
+            )
+
+        if interval_counts:
+            self._interval_snapshots.append({
+                "time": timestamp,
+                "counts": interval_counts,
+            })
+            self._intervals_processed += 1
+
+    def _ingest_warning_line(self, json_obj, stats, message):
+        namespace = stats.get("namespace")
+        if not namespace:
+            return
+
+        total_events = int(stats.get("totalEvents") or 0)
+        events_per_type = stats.get("totalEventsPerType") or {}
+        spread_disparity = stats.get("spreadDisparity")
+        self._record_event_types(events_per_type)
+
+        ns_stats = self._namespace_stats(namespace)
+        ns_stats.add_collection(namespace, total_events, events_per_type)
+        ns_stats.add_warning(spread_disparity)
+
+        warning_type = "hot_doc"
+        if message.startswith(BUSY_AGG_OUT_PREFIX):
+            warning_type = "agg_out"
+
+        self._warnings.append({
+            "time": json_obj.get("time") or "",
+            "level": json_obj.get("level") or "warn",
+            "message": message,
+            "namespace": namespace,
+            "warningType": warning_type,
+            "spreadDisparity": spread_disparity,
+            "totalEvents": total_events,
+            "totalEventsPerType": dict(events_per_type),
+        })
+
+        timestamp = json_obj.get("time") or ""
+        self._interval_snapshots.append({
+            "time": timestamp,
+            "counts": {namespace: total_events},
+        })
+
+    def finalize(self):
+        """Return summary, timeseries, warnings, and meta for template rendering."""
+        summary = []
+        for namespace, ns_stats in self._namespaces.items():
+            summary.append({
+                "namespace": namespace,
+                "totalEvents": ns_stats.total_events,
+                "totalEventsPerType": dict(ns_stats.total_events_per_type),
+                "warningCount": ns_stats.warning_count,
+                "maxSpreadDisparity": ns_stats.max_spread_disparity,
+            })
+        summary.sort(key=lambda row: row["totalEvents"], reverse=True)
+
+        timeseries = self._build_timeseries(summary)
+        event_types = sorted(self._event_types)
+
+        return {
+            "summary": summary,
+            "timeseries": timeseries,
+            "warnings": list(self._warnings),
+            "eventTypes": event_types,
+            "meta": {
+                "intervalSecs": INTERVAL_SECS,
+                "topNPerInterval": TOP_N_PER_INTERVAL,
+                "intervalsProcessed": self._intervals_processed,
+                "namespacesSeen": len(self._namespaces),
+                "skippedOutsideCea": self._skipped_outside_cea,
+            },
+        }
+
+    def _build_timeseries(self, summary):
+        if not self._interval_snapshots:
+            return {"times": [], "series": {}}
+
+        top_namespaces = [
+            row["namespace"] for row in summary[:CHART_TOP_N]
+        ]
+        if not top_namespaces:
+            return {"times": [], "series": {}}
+
+        times = [snapshot["time"] for snapshot in self._interval_snapshots]
+        series = {namespace: [] for namespace in top_namespaces}
+        for snapshot in self._interval_snapshots:
+            counts = snapshot.get("counts") or {}
+            for namespace in top_namespaces:
+                series[namespace].append(int(counts.get(namespace, 0)))
+
+        return {"times": times, "series": series}
+
+
+def build_busiest_collections_plot(timeseries, meta=None):
+    """Build Plotly JSON for top-namespace CEA write activity over time."""
+    times = timeseries.get("times") or []
+    series = timeseries.get("series") or {}
+    if not times or not series:
+        return ""
+
+    parsed_times = []
+    for ts in times:
+        try:
+            parsed_times.append(
+                datetime.strptime(ts[:26], "%Y-%m-%dT%H:%M:%S.%f"),
+            )
+        except (ValueError, TypeError):
+            parsed_times.append(ts)
+
+    fig = go.Figure()
+    for namespace, values in series.items():
+        fig.add_trace(go.Scatter(
+            x=parsed_times,
+            y=values,
+            mode="lines",
+            name=namespace,
+            stackgroup="cea_writes",
+        ))
+
+    interval_secs = (meta or {}).get("intervalSecs", INTERVAL_SECS)
+    apply_mi_theme(
+        fig,
+        title=(
+            f"CEA write activity by namespace "
+            f"(top {CHART_TOP_N}, {interval_secs}s intervals)"
+        ),
+        height=420,
+        width=1450,
+        legend_tracegroupgap=120,
+    )
+    fig.update_layout(
+        xaxis_title="Time",
+        yaxis_title="Write operations per interval",
+    )
+    return json.dumps(fig, cls=PlotlyJSONEncoder)

--- a/migration/mongosync_insights/lib/logs_metrics.py
+++ b/migration/mongosync_insights/lib/logs_metrics.py
@@ -30,6 +30,11 @@ from .plot_theme import apply_mi_theme, section_label_style
 from .log_store import LogStore
 from .log_store_registry import log_store_registry
 from .snapshot_store import save_snapshot
+from .busiest_collections import (
+    BusiestCollectionsAccumulator,
+    build_busiest_collections_plot,
+    update_in_cea_phase,
+)
 
 _DECOMPRESS_ERRORS = (
     ValueError,
@@ -306,6 +311,9 @@ def upload_file():
         db_path = logstore_path(store_id)
         log_store = LogStore(db_path)
         
+        busiest_collections_accumulator = BusiestCollectionsAccumulator()
+        in_cea_phase = False
+        
         # Single pass through the file with streaming
         line_count = 0
         logs_line_count = 0
@@ -407,9 +415,19 @@ def upload_file():
                 
                     if patterns['phase_transitions'].search(message):
                         phase_transitions_json.append(json_obj)
+                        phase_event = _phase_event_from_info(json_obj)
+                        if phase_event:
+                            in_cea_phase = update_in_cea_phase(
+                                in_cea_phase, phase_event[1],
+                            )
 
                     if patterns['phase_in_memory'].search(message):
                         phase_in_memory_json.append(json_obj)
+                        phase_event = _phase_event_from_in_memory(json_obj)
+                        if phase_event:
+                            in_cea_phase = update_in_cea_phase(
+                                in_cea_phase, phase_event[1],
+                            )
                 
                     if patterns['mongosync_options'].search(message):
                         # Filter out time and level fields for options
@@ -471,6 +489,10 @@ def upload_file():
                                 'full_log': json.dumps(json_obj, indent=2)
                             })
                             break  # Only match first pattern per message
+
+                    busiest_collections_accumulator.ingest_line(
+                        json_obj, in_cea_phase=in_cea_phase,
+                    )
                     
                 except json.JSONDecodeError as e:
                     invalid_json_count += 1
@@ -1567,6 +1589,23 @@ def upload_file():
         has_logs_data = logs_line_count > 0 and len(data) > 0
         has_metrics_data = metrics_collector.metrics_count > 0
 
+        busiest_collections_result = busiest_collections_accumulator.finalize()
+        busiest_collections_data = busiest_collections_result["summary"]
+        busiest_collections_warnings = busiest_collections_result["warnings"]
+        busiest_collections_meta = busiest_collections_result["meta"]
+        busiest_collections_event_types = busiest_collections_result["eventTypes"]
+        busiest_collections_plot_json = ""
+        if busiest_collections_result["timeseries"]["times"]:
+            busiest_collections_plot_json = build_busiest_collections_plot(
+                busiest_collections_result["timeseries"],
+                busiest_collections_meta,
+            )
+        has_busiest_collections_data = bool(
+            busiest_collections_data
+            or busiest_collections_warnings
+            or busiest_collections_plot_json
+        )
+
         template_data = {
             'plot_json': plot_json,
             'metrics_plot_json': metrics_plot_json,
@@ -1582,6 +1621,12 @@ def upload_file():
             'log_viewer_lines': log_viewer_lines_out,
             'log_viewer_max_lines': LOG_VIEWER_MAX_LINES,
             'log_store_id': store_id,
+            'busiest_collections_data': busiest_collections_data,
+            'busiest_collections_warnings': busiest_collections_warnings,
+            'busiest_collections_meta': busiest_collections_meta,
+            'busiest_collections_event_types': busiest_collections_event_types,
+            'busiest_collections_plot_json': busiest_collections_plot_json,
+            'has_busiest_collections_data': has_busiest_collections_data,
         }
 
         snapshot_id = str(uuid_mod.uuid4())

--- a/migration/mongosync_insights/static/css/mi-upload-results.css
+++ b/migration/mongosync_insights/static/css/mi-upload-results.css
@@ -818,3 +818,23 @@
     border-color: var(--mi-disclaimer-border);
     color: var(--lm-text-primary);
 }
+
+.ur-main .busiest-info-banner {
+    margin: 16px 20px 0;
+    padding: 12px 16px;
+    border-radius: var(--lm-card-radius);
+    border: 1px solid var(--mi-disclaimer-border);
+    background: var(--mi-disclaimer-bg);
+    color: var(--lm-text-primary);
+    font-size: 14px;
+    line-height: 1.5;
+}
+
+.ur-main .busiest-chart-wrapper {
+    margin: 16px 20px 0;
+}
+
+.ur-main .busiest-logviewer-btn {
+    font-size: 12px;
+    padding: 4px 10px;
+}

--- a/migration/mongosync_insights/templates/upload_results.html
+++ b/migration/mongosync_insights/templates/upload_results.html
@@ -25,6 +25,9 @@
         {% if has_logs_data %}
         <button class="tab-btn" onclick="switchTab('options')" id="tab-options">Mongosync Options</button>
         <button class="tab-btn" onclick="switchTab('collections')" id="tab-collections">Collections and Partitions</button>
+        {% if has_busiest_collections_data %}
+        <button class="tab-btn" onclick="switchTab('busiest')" id="tab-busiest">CEA Busiest Collections{% if busiest_collections_data %} ({{ busiest_collections_data|length }}){% endif %}</button>
+        {% endif %}
         <button class="tab-btn" onclick="switchTab('errors')" id="tab-errors">Errors and Warnings{% if errors_data %} ({{ errors_data|length }}){% endif %}</button>
         <button class="tab-btn" onclick="switchTab('logviewer')" id="tab-logviewer">Log Viewer</button>
         {% endif %}
@@ -249,6 +252,114 @@
             </div>
         </div>
     </div>
+
+    {% if has_busiest_collections_data %}
+    <div id="busiest-tab" class="tab-content">
+        <div class="plot-container">
+            <div class="busiest-info-banner" role="note">
+                <strong>About this data:</strong>
+                Aggregated from mongosync CEA (change event application) statistics logged every
+                {{ busiest_collections_meta.intervalSecs }}s. Each interval reports only the top
+                {{ busiest_collections_meta.topNPerInterval }} busiest collections, so totals are
+                approximate and may under-count namespaces outside that window.
+                Requires the log segment that includes CEA at default <code>info</code> verbosity.
+            </div>
+
+            {% if busiest_collections_plot_json %}
+            <div class="busiest-chart-wrapper">
+                <div id="busiest-collections-plot"></div>
+            </div>
+            {% endif %}
+
+            <div class="filter-container">
+                <input type="text" id="busiest-filter" class="filter-input"
+                       placeholder="Filter by namespace..."
+                       oninput="filterBusiestCollectionsTable(this.value)">
+            </div>
+
+            <div class="options-container">
+                <div class="options-table-wrapper" style="max-width: 100%; min-width: 100%;">
+                    <div class="table-header">
+                        <h3>Namespace write activity (CEA)</h3>
+                        {% if busiest_collections_data %}
+                        <button class="copy-btn" onclick="copyBusiestCollectionsAsMarkdown(this)">Copy as Markdown</button>
+                        {% endif %}
+                    </div>
+                    {% if busiest_collections_data %}
+                    <table class="options-table" id="busiest-collections-table">
+                        <thead>
+                            <tr>
+                                <th class="sortable-th" data-label="Namespace" onclick="sortTableByColumn('busiest-collections-table', 0, 'text')" title="Click to sort">Namespace</th>
+                                <th class="sortable-th" data-label="Total Write Ops" onclick="sortTableByColumn('busiest-collections-table', 1, 'numeric')" title="Click to sort">Total Write Ops</th>
+                                {% for event_type in busiest_collections_event_types %}
+                                <th class="sortable-th" data-label="{{ event_type }}" onclick="sortTableByColumn('busiest-collections-table', {{ loop.index + 2 }}, 'numeric')" title="Click to sort">{{ event_type }}</th>
+                                {% endfor %}
+                                <th class="sortable-th" data-label="Warnings" onclick="sortTableByColumn('busiest-collections-table', {{ busiest_collections_event_types|length + 2 }}, 'numeric')" title="Click to sort">Warnings</th>
+                                <th class="sortable-th" data-label="Max Spread Disparity" onclick="sortTableByColumn('busiest-collections-table', {{ busiest_collections_event_types|length + 3 }}, 'numeric')" title="Click to sort">Max Spread Disparity</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for row in busiest_collections_data %}
+                            <tr>
+                                <td class="key-cell">{{ row.namespace }}</td>
+                                <td>{{ "{:,}".format(row.totalEvents) }}</td>
+                                {% for event_type in busiest_collections_event_types %}
+                                <td>{{ "{:,}".format(row.totalEventsPerType.get(event_type, 0)) }}</td>
+                                {% endfor %}
+                                <td>{{ row.warningCount }}</td>
+                                <td>{{ row.maxSpreadDisparity if row.maxSpreadDisparity is not none else '—' }}</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                    <div class="no-results" id="busiest-no-results">No matching namespaces found</div>
+                    {% else %}
+                    <div class="no-data-message">No namespace summary data found in the uploaded log.</div>
+                    {% endif %}
+                </div>
+
+                {% if busiest_collections_warnings %}
+                <div class="options-table-wrapper" style="max-width: 100%; min-width: 100%;">
+                    <div class="table-header">
+                        <h3>CEA workload warnings</h3>
+                    </div>
+                    <table class="options-table" id="busiest-warnings-table">
+                        <thead>
+                            <tr>
+                                <th class="sortable-th" data-label="Time" onclick="sortTableByColumn('busiest-warnings-table', 0, 'date')" title="Click to sort">Time</th>
+                                <th class="sortable-th" data-label="Namespace" onclick="sortTableByColumn('busiest-warnings-table', 1, 'text')" title="Click to sort">Namespace</th>
+                                <th class="sortable-th" data-label="Type" onclick="sortTableByColumn('busiest-warnings-table', 2, 'text')" title="Click to sort">Type</th>
+                                <th class="sortable-th" data-label="Spread Disparity" onclick="sortTableByColumn('busiest-warnings-table', 3, 'numeric')" title="Click to sort">Spread Disparity</th>
+                                <th class="sortable-th" data-label="Total Events" onclick="sortTableByColumn('busiest-warnings-table', 4, 'numeric')" title="Click to sort">Total Events</th>
+                                <th class="sortable-th" data-label="Message" onclick="sortTableByColumn('busiest-warnings-table', 5, 'text')" title="Click to sort">Message</th>
+                                <th>Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for warning in busiest_collections_warnings %}
+                            <tr>
+                                <td>{{ warning.time }}</td>
+                                <td class="key-cell">{{ warning.namespace }}</td>
+                                <td>{{ 'Hot document' if warning.warningType == 'hot_doc' else '$out aggregation' }}</td>
+                                <td>{{ warning.spreadDisparity if warning.spreadDisparity is not none else '—' }}</td>
+                                <td>{{ "{:,}".format(warning.totalEvents) }}</td>
+                                <td class="value-cell">{{ warning.message }}</td>
+                                <td>
+                                    <button type="button" class="copy-btn busiest-logviewer-btn"
+                                            onclick="lvFocusNamespace({{ warning.namespace | tojson }})">
+                                        View in Log Viewer
+                                    </button>
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+    {% endif %}
 
     <div id="errors-tab" class="tab-content">
         <div class="plot-container">
@@ -635,6 +746,11 @@ if (metricsPlot && metricsPlot.data) {
 }
 {% endif %}
 
+{% if busiest_collections_plot_json %}
+var busiestCollectionsPlot = {{ busiest_collections_plot_json | safe }};
+var busiestCollectionsPlotRendered = false;
+{% endif %}
+
 // Store table data for Markdown conversion
 var optionsData = {{ options_data | tojson }};
 var hiddenOptionsData = {{ hidden_options_data | tojson }};
@@ -643,6 +759,24 @@ var naturalOrderData = {{ natural_order_data | tojson }};
 var errorsData = {{ errors_data | tojson }};
 var partitionInitData = {{ partition_init_data | tojson }};
 var progressData = {{ progress_data | default([]) | tojson }};
+var busiestCollectionsData = {{ busiest_collections_data | default([]) | tojson }};
+var busiestCollectionsEventTypes = {{ busiest_collections_event_types | default([]) | tojson }};
+
+function renderBusiestCollectionsPlot() {
+    if (typeof busiestCollectionsPlot === 'undefined' || busiestCollectionsPlotRendered) {
+        return;
+    }
+    if (!busiestCollectionsPlot || !busiestCollectionsPlot.data) {
+        return;
+    }
+    busiestCollectionsPlotRendered = true;
+    miRenderPlot('busiest-collections-plot', busiestCollectionsPlot, {
+        onRendered: function(elId) {
+            buildInfoOverlay(elId);
+            bindInfoOverlayEvents(elId);
+        }
+    });
+}
 
 function switchTab(tabName) {
     document.querySelectorAll('.tab-btn').forEach(btn => btn.classList.remove('active'));
@@ -650,6 +784,10 @@ function switchTab(tabName) {
 
     document.querySelectorAll('.tab-content').forEach(content => content.classList.remove('active'));
     document.getElementById(tabName + '-tab').classList.add('active');
+
+    if (tabName === 'busiest') {
+        renderBusiestCollectionsPlot();
+    }
 
     if (tabName === 'logviewer' && !lvInitialized && LV_INITIAL_LINES && LV_INITIAL_LINES.length > 0) {
         lvInitialized = true;
@@ -1060,6 +1198,90 @@ function copyPartitionInitAsMarkdown(buttonElement) {
         console.error('Failed to copy: ', err);
         fallbackCopyToClipboard(markdown, buttonElement);
     });
+}
+
+function filterBusiestCollectionsTable(searchText) {
+    var filter = searchText.toLowerCase().trim();
+    var table = document.getElementById('busiest-collections-table');
+    if (!table) return;
+
+    var rows = table.querySelectorAll('tbody tr');
+    var visibleCount = 0;
+
+    rows.forEach(function(row) {
+        var match = false;
+        row.querySelectorAll('td').forEach(function(cell) {
+            if (cell.textContent.toLowerCase().includes(filter)) {
+                match = true;
+            }
+        });
+        if (filter === '' || match) {
+            row.style.display = '';
+            visibleCount++;
+        } else {
+            row.style.display = 'none';
+        }
+    });
+
+    var noResultsMsg = document.getElementById('busiest-no-results');
+    if (noResultsMsg) {
+        noResultsMsg.style.display = (visibleCount === 0 && filter !== '') ? 'block' : 'none';
+    }
+}
+
+function copyBusiestCollectionsAsMarkdown(buttonElement) {
+    if (!busiestCollectionsData || busiestCollectionsData.length === 0) {
+        return;
+    }
+
+    var headers = ['Namespace', 'Total Write Ops'].concat(busiestCollectionsEventTypes || [])
+        .concat(['Warnings', 'Max Spread Disparity']);
+    var markdown = '## CEA Busiest Collections\n\n';
+    markdown += '| ' + headers.join(' | ') + ' |\n';
+    markdown += '|' + headers.map(function() { return '---'; }).join('|') + '|\n';
+
+    busiestCollectionsData.forEach(function(row) {
+        var cells = [
+            row.namespace,
+            String(row.totalEvents),
+        ];
+        (busiestCollectionsEventTypes || []).forEach(function(eventType) {
+            var counts = row.totalEventsPerType || {};
+            cells.push(String(counts[eventType] || 0));
+        });
+        cells.push(String(row.warningCount || 0));
+        cells.push(
+            row.maxSpreadDisparity !== null && row.maxSpreadDisparity !== undefined
+                ? String(row.maxSpreadDisparity)
+                : '—'
+        );
+        markdown += '| ' + cells.map(function(cell) {
+            return String(cell).replace(/\|/g, '\\|');
+        }).join(' | ') + ' |\n';
+    });
+
+    navigator.clipboard.writeText(markdown).then(function() {
+        var originalText = buttonElement.textContent;
+        buttonElement.textContent = 'Copied!';
+        buttonElement.classList.add('copied');
+        setTimeout(function() {
+            buttonElement.textContent = originalText;
+            buttonElement.classList.remove('copied');
+        }, 2000);
+    }).catch(function(err) {
+        console.error('Failed to copy: ', err);
+        fallbackCopyToClipboard(markdown, buttonElement);
+    });
+}
+
+function lvFocusNamespace(namespace) {
+    if (!namespace) return;
+    switchTab('logviewer');
+    var searchInput = document.getElementById('lvSearchInput');
+    if (searchInput) {
+        searchInput.value = namespace;
+        lvOnSearchInput(namespace);
+    }
 }
 
 function copyNaturalOrderAsMarkdown(buttonElement) {

--- a/migration/mongosync_insights/tests/conftest.py
+++ b/migration/mongosync_insights/tests/conftest.py
@@ -76,6 +76,12 @@ def minimal_template_data():
         "log_viewer_lines": [],
         "log_viewer_max_lines": 1000,
         "log_store_id": "",
+        "busiest_collections_data": [],
+        "busiest_collections_warnings": [],
+        "busiest_collections_meta": {},
+        "busiest_collections_event_types": [],
+        "busiest_collections_plot_json": "",
+        "has_busiest_collections_data": False,
     }
 
 

--- a/migration/mongosync_insights/tests/test_busiest_collections.py
+++ b/migration/mongosync_insights/tests/test_busiest_collections.py
@@ -1,0 +1,158 @@
+"""Tests for CEA busiest collections parsing."""
+import json
+
+import pytest
+
+from lib.busiest_collections import (
+    CRUD_STATS_MESSAGE,
+    BusiestCollectionsAccumulator,
+    build_busiest_collections_plot,
+    update_in_cea_phase,
+)
+
+
+def _info_line(time, collections, hot_docs=0):
+    return {
+        "time": time,
+        "level": "info",
+        "message": CRUD_STATS_MESSAGE,
+        "recentCRUDStatistics": {
+            "totalHotDocEvents": hot_docs,
+            "busiestCollections": collections,
+        },
+    }
+
+
+def _warn_line(time, namespace, message, spread=12.5, total=1000):
+    return {
+        "time": time,
+        "level": "warn",
+        "message": message,
+        "recentCRUDStatistics": {
+            "namespace": namespace,
+            "totalEvents": total,
+            "spreadDisparity": spread,
+            "totalEventsPerType": {"update": total},
+        },
+    }
+
+
+class TestUpdateInCeaPhase:
+    def test_enters_cea(self):
+        assert update_in_cea_phase(False, "change event application") is True
+
+    def test_leaves_cea_on_commit(self):
+        assert update_in_cea_phase(True, "commit handler called") is False
+
+    def test_unchanged_for_other_phases(self):
+        assert update_in_cea_phase(True, "collection copy") is True
+
+
+class TestBusiestCollectionsAccumulator:
+    def test_accumulates_info_line_busiest_collections(self):
+        acc = BusiestCollectionsAccumulator()
+        acc.ingest_line(_info_line("2026-01-01T12:00:10.000000Z", [{
+            "namespace": "db.coll",
+            "totalEvents": 100,
+            "totalEventsPerType": {"insert": 60, "update": 40},
+        }]), in_cea_phase=True)
+        acc.ingest_line(_info_line("2026-01-01T12:00:20.000000Z", [{
+            "namespace": "db.coll",
+            "totalEvents": 50,
+            "totalEventsPerType": {"insert": 20, "update": 30},
+        }]), in_cea_phase=True)
+
+        result = acc.finalize()
+        assert len(result["summary"]) == 1
+        row = result["summary"][0]
+        assert row["namespace"] == "db.coll"
+        assert row["totalEvents"] == 150
+        assert row["totalEventsPerType"]["insert"] == 80
+        assert row["totalEventsPerType"]["update"] == 70
+        assert result["meta"]["intervalsProcessed"] == 2
+
+    def test_skips_outside_cea_phase(self):
+        acc = BusiestCollectionsAccumulator()
+        acc.ingest_line(_info_line("2026-01-01T12:00:10.000000Z", [{
+            "namespace": "db.coll",
+            "totalEvents": 100,
+            "totalEventsPerType": {"insert": 100},
+        }]), in_cea_phase=False)
+
+        result = acc.finalize()
+        assert result["summary"] == []
+        assert result["meta"]["skippedOutsideCea"] == 1
+
+    def test_ingests_warning_line_single_collection(self):
+        acc = BusiestCollectionsAccumulator()
+        warn = _warn_line(
+            "2026-01-01T12:01:00.000000Z",
+            "db.hot",
+            "The level of CEA parallelization for this collection is low. Example",
+            spread=15.2,
+            total=1200,
+        )
+        acc.ingest_line(warn, in_cea_phase=True)
+
+        result = acc.finalize()
+        assert len(result["warnings"]) == 1
+        assert result["warnings"][0]["namespace"] == "db.hot"
+        assert result["warnings"][0]["warningType"] == "hot_doc"
+        assert result["summary"][0]["totalEvents"] == 1200
+        assert result["summary"][0]["warningCount"] == 1
+        assert result["summary"][0]["maxSpreadDisparity"] == 15.2
+
+    def test_dynamic_event_types_in_summary(self):
+        acc = BusiestCollectionsAccumulator()
+        acc.ingest_line(_info_line("2026-01-01T12:00:10.000000Z", [{
+            "namespace": "db.a",
+            "totalEvents": 10,
+            "totalEventsPerType": {"insert": 10},
+        }]), in_cea_phase=True)
+        acc.ingest_line(_info_line("2026-01-01T12:00:20.000000Z", [{
+            "namespace": "db.b",
+            "totalEvents": 5,
+            "totalEventsPerType": {"replace": 5},
+        }]), in_cea_phase=True)
+
+        result = acc.finalize()
+        assert "insert" in result["eventTypes"]
+        assert "replace" in result["eventTypes"]
+
+    def test_finalize_sorts_by_total_events(self):
+        acc = BusiestCollectionsAccumulator()
+        acc.ingest_line(_info_line("2026-01-01T12:00:10.000000Z", [
+            {"namespace": "db.low", "totalEvents": 10, "totalEventsPerType": {"insert": 10}},
+            {"namespace": "db.high", "totalEvents": 99, "totalEventsPerType": {"insert": 99}},
+        ]), in_cea_phase=True)
+
+        result = acc.finalize()
+        assert [row["namespace"] for row in result["summary"]] == ["db.high", "db.low"]
+
+    def test_empty_finalize(self):
+        result = BusiestCollectionsAccumulator().finalize()
+        assert result["summary"] == []
+        assert result["warnings"] == []
+        assert result["timeseries"]["times"] == []
+        assert result["meta"]["intervalsProcessed"] == 0
+
+
+class TestBuildBusiestCollectionsPlot:
+    def test_build_plot_returns_json(self):
+        timeseries = {
+            "times": [
+                "2026-01-01T12:00:10.000000Z",
+                "2026-01-01T12:00:20.000000Z",
+            ],
+            "series": {
+                "db.coll": [100, 80],
+            },
+        }
+        plot_json = build_busiest_collections_plot(timeseries, {"intervalSecs": 10})
+        assert plot_json
+        payload = json.loads(plot_json)
+        assert payload["data"]
+        assert len(payload["data"]) == 1
+
+    def test_build_plot_empty_returns_blank(self):
+        assert build_busiest_collections_plot({"times": [], "series": {}}) == ""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a dedicated **CEA Busiest Collections** tab to the Log Analyzer, porting the toolbox `get-busiest-collections.js` logic into MI's Python parse pipeline (the toolbox script is unchanged).

- Parses mongosync CEA CRUD statistics during the existing single-pass log upload
- Tracks CEA phase boundaries so only change-event-application stats are counted
- Shows a time-series chart (top 10 namespaces), cumulative summary table, and CEA workload warnings
- Supports Copy as Markdown and Log Viewer cross-links for warning namespaces
- Persists results in analysis snapshots

## Behavior

- **Info lines**: `"Recent CRUD change event statistics."` → aggregates `recentCRUDStatistics.busiestCollections`
- **Warn lines**: hot-document / `$out` workload warnings with single-collection `recentCRUDStatistics`
- **Limitations** documented in UI: top 20 collections per 10s interval; totals are approximate

## Tests

- 11 new unit tests in `tests/test_busiest_collections.py`
- Full suite: 527 passed

## Docs

- `LOG_ANALYZER.md` — new tab description
- `LOG_VERBOSITY.md` — CEA panel source patterns
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4eab9b4-4cc1-4799-9fac-d0f31aa57124?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4eab9b4-4cc1-4799-9fac-d0f31aa57124&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

