### PR TITLE
Log Analyzer Summary tab

### DIFF
--- a/migration/mongosync_insights/LOG_ANALYZER.md
+++ b/migration/mongosync_insights/LOG_ANALYZER.md
@@ -23,7 +23,7 @@ Maximum upload size defaults to **10 GB** (`MI_MAX_FILE_SIZE`).
 
 Mongosync Insights detects two kinds of content in the uploaded file:
 
-1. **Structured mongosync JSON log lines** — the main migration log (`mongosync.log` or rotated segments). These drive the **Mongosync Logs**, **Errors and Warnings**, and **Log Viewer** tabs.
+1. **Structured mongosync JSON log lines** — the main migration log (`mongosync.log` or rotated segments). These drive the **Summary**, **Mongosync Logs**, **Errors and Warnings**, and **Log Viewer** tabs.
 2. **Prometheus metrics lines** — from `mongosync_metrics.log`. These drive the **Mongosync Metrics** tab.
 
 A single upload can contain log lines only, metrics only, or both. Tabs appear based on what was found.
@@ -59,12 +59,22 @@ After parsing, the results page shows one or more tabs:
 
 | Tab | When shown | Purpose |
 |-----|------------|---------|
+| **Summary** | Log lines found | Snapshot of the latest migration state, using the same cards as Migration Monitoring |
 | **Mongosync Logs** | Log lines found | Time-series charts: phases, lag, copy progress, CEA, indexes, verifier, etc. |
 | **Mongosync Metrics** | Prometheus metrics found | Charts from `mongosync_metrics.json` (OTel/Prometheus exposition in log lines) |
 | **Mongosync Options** | Log lines found | Version info, startup options, hidden flags, `/api/v1/start` request body |
 | **Collections and Partitions** | Log lines found | Natural-order collections and per-collection partition tables |
 | **Errors and Warnings** | Log lines found | Pattern-matched errors with optional recommendations |
 | **Log Viewer** | Log lines found | Tail view and full-text search over indexed log lines |
+
+### Summary
+
+The Summary tab reuses the Migration Monitoring layout (state badge, copy progress, lag, index building, direction mapping, embedded verifier, filters) but is **not live**. Values come from:
+
+1. The **latest `/api/v1/progress` body** recorded in `sent response` log lines (primary source for state, copy bytes, lag, canCommit/canWrite, index building, verifier, direction).
+2. **Other log events** already used for charts and tables: phase transitions, `/api/v1/start` options, natural-order collections, and partition copy counts.
+
+The subtitle shows the timestamp of that latest `/progress` line so it is clear the page is a snapshot from the uploaded file.
 
 ### Mongosync Logs
 
@@ -160,7 +170,7 @@ See **[CONFIGURATION.md](CONFIGURATION.md)** for examples (upload size, persiste
 | | Log Analyzer | Migration Monitoring |
 |---|--------------|----------------------|
 | **Input** | Upload log/metrics files | Live connection string and/or progress endpoint |
-| **Timing** | Post-hoc / historical | Real-time polling |
+| **Timing** | Post-hoc / historical (Summary tab is a snapshot of the latest `/progress` in the log) | Real-time polling |
 | **Best for** | Deep dive on completed or in-progress runs from logs | Live dashboard while mongosync is running |
 
 Use both when troubleshooting: Migration Monitoring for current state, Log Analyzer for historical trends and full log search.

--- a/migration/mongosync_insights/lib/live_metadata_status.py
+++ b/migration/mongosync_insights/lib/live_metadata_status.py
@@ -279,8 +279,8 @@ def format_namespace_filter_rows(filter_data, filter_type="inclusion"):
     """
     if not filter_data:
         if filter_type == "inclusion":
-            return [{"key": "Database", "value": "All (no filter)"}]
-        return [{"key": "Filter", "value": "No filter"}]
+            return [{"key": "Database", "value": "All (no filter specified)"}]
+        return [{"key": "Filter", "value": "None (No filter specified)"}]
 
     keys = []
     values = []
@@ -298,7 +298,9 @@ def format_namespace_filter_rows(filter_data, filter_type="inclusion"):
                     else:
                         db_list.append(str(db))
                 keys.append("Database")
-                values.append(", ".join(db_list) if db_list else "All (no filter)")
+                values.append(
+                    ", ".join(db_list) if db_list else "All (no filter specified)"
+                )
 
         collections = item.get("collections")
         if collections:
@@ -310,12 +312,12 @@ def format_namespace_filter_rows(filter_data, filter_type="inclusion"):
                 values.append(str(collections))
         elif collections is None and database:
             keys.append("Collections")
-            values.append("All (no filter)")
+            values.append("All (no filter specified)")
 
     if not keys:
         if filter_type == "inclusion":
-            return [{"key": "Database", "value": "All (no filter)"}]
-        return [{"key": "Filter", "value": "No filter"}]
+            return [{"key": "Database", "value": "All (no filter specified)"}]
+        return [{"key": "Filter", "value": "None (No filter specified)"}]
 
     return [{"key": k, "value": v} for k, v in zip(keys, values)]
 

--- a/migration/mongosync_insights/lib/live_monitoring.py
+++ b/migration/mongosync_insights/lib/live_monitoring.py
@@ -26,6 +26,12 @@ from .utils import (
     format_count,
     format_lag_time_seconds,
     format_ratio,
+    format_seconds_title,
+)
+
+_MIGRATION_START_TIME_TITLE = (
+    "This is the time when the phase changes from uninitialized to "
+    "Starting initializing collections and indexes after /start is issued"
 )
 
 logger = logging.getLogger(__name__)
@@ -173,13 +179,19 @@ def _display_or_dash(value):
     return str(value)
 
 
-def _build_metadata_metrics(metadata):
+def _build_metadata_metrics(metadata, *, summary=False):
     """Second metrics row from internal database (connection string required)."""
     if not metadata:
         return []
+    finish_label = "Migration Committed" if summary else "Finish"
     return [
-        {"label": "Start", "value": _display_or_dash(metadata.get("start")), "small": True},
-        {"label": "Finish", "value": _display_or_dash(metadata.get("finish")), "small": True},
+        {
+            "label": "Migration Start time",
+            "value": _display_or_dash(metadata.get("start")),
+            "title": _MIGRATION_START_TIME_TITLE,
+            "small": True,
+        },
+        {"label": finish_label, "value": _display_or_dash(metadata.get("finish")), "small": True},
         {
             "label": "Reversible",
             "value": _display_or_dash(metadata.get("reversible")),
@@ -203,20 +215,40 @@ def _build_metadata_metrics(metadata):
     ]
 
 
+def _duration_metric(label, seconds, *, small=False):
+    item = {
+        "label": label,
+        "value": format_lag_time_seconds(seconds),
+        "small": small,
+    }
+    title = format_seconds_title(seconds)
+    if title:
+        item["title"] = title
+    if label == "Lag time" and seconds is not None and seconds > 60:
+        item["highLag"] = True
+    return item
+
+
+def _copied_bytes_title(copied, total):
+    if copied is None and total is None:
+        return None
+    return f"{format_count(copied)} of {format_count(total)} bytes"
+
+
 def _build_progress_metrics(progress, lag_seconds):
     return [
-        {"label": "Lag time", "value": format_lag_time_seconds(lag_seconds), "small": False},
+        _duration_metric("Lag time", lag_seconds, small=False),
         {"label": "Events applied", "value": format_count(progress.get("totalEventsApplied")), "small": False},
         {
             "label": "Oplog window left",
             "value": progress.get("estimatedOplogTimeRemaining") or "—",
             "small": True,
         },
-        {
-            "label": "Catch-up estimate",
-            "value": format_lag_time_seconds(progress.get("estimatedSecondsToCEACatchup")),
-            "small": True,
-        },
+        _duration_metric(
+            "Catch-up estimate",
+            progress.get("estimatedSecondsToCEACatchup"),
+            small=True,
+        ),
         {
             "label": "Can commit",
             "value": "TRUE" if progress.get("canCommit") else "FALSE",
@@ -234,7 +266,7 @@ def _build_progress_metrics(progress, lag_seconds):
 
 def _build_db_only_metrics(lag_seconds):
     return [
-        {"label": "Lag time", "value": format_lag_time_seconds(lag_seconds), "small": False},
+        _duration_metric("Lag time", lag_seconds, small=False),
         {"label": "Events applied", "value": "—", "small": False},
         {"label": "Oplog window left", "value": "—", "small": True},
         {"label": "Catch-up estimate", "value": "—", "small": True},
@@ -273,6 +305,33 @@ def _build_partitions_copied_label(metadata):
     return f"Partitions copied: {format_count(copied)} of {format_count(total)}"
 
 
+def _bytes_copy_percent(copied, total):
+    """Progress bar percent from estimated copied bytes vs total bytes."""
+    if not total or total <= 0:
+        return None
+    if copied is None:
+        copied = 0
+    return min(100.0, (copied / total) * 100)
+
+
+def _build_collections_finished_label(progress=None, metadata=None, *, progress_available=False):
+    coll_finished = None
+    coll_total = None
+    if progress_available and progress:
+        index_building = progress.get("indexBuilding") or {}
+        if isinstance(index_building, dict):
+            coll_finished = index_building.get("collectionsFinished")
+            coll_total = index_building.get("collectionsTotal")
+    if coll_total is None and metadata:
+        coll_finished = metadata.get("indexCollectionsFinished")
+        coll_total = metadata.get("indexCollectionsTotal")
+    if not coll_total or coll_total <= 0:
+        return None
+    if coll_finished is None:
+        coll_finished = 0
+    return f"Collections Copied: {format_count(coll_finished)} of {format_count(coll_total)}"
+
+
 def _build_phase_start_times(metadata):
     if not metadata:
         return None
@@ -286,7 +345,28 @@ def _build_phase_start_times(metadata):
     }
 
 
-def _build_sync_card(progress=None, metadata=None, *, progress_available=False):
+def _apply_summary_mongosync_version(sync_card, *, summary=False, mongosync_version=None):
+    if not summary:
+        return sync_card
+    sync_card["showMongosyncVersion"] = True
+    if mongosync_version:
+        sync_card["mongosyncVersion"] = mongosync_version
+    else:
+        sync_card["mongosyncVersionMissingTitle"] = (
+            "Missing initial log file for version capture.\n"
+            "Upload all rotated mongosync files for full analysis"
+        )
+    return sync_card
+
+
+def _build_sync_card(
+    progress=None,
+    metadata=None,
+    *,
+    progress_available=False,
+    summary=False,
+    mongosync_version=None,
+):
     if progress_available and progress:
         info = progress.get("info") or ""
         info_lower = info.lower()
@@ -299,28 +379,33 @@ def _build_sync_card(progress=None, metadata=None, *, progress_available=False):
         total = collection_copy.get("estimatedTotalBytes")
         state = (progress.get("state") or "").upper()
 
-        copy_percent = None
-        if total and total > 0 and copied is not None:
-            copy_percent = min(100.0, (copied / total) * 100)
-
+        copy_percent = _bytes_copy_percent(copied, total)
         copy_indeterminate = copy_percent is None and state in ("RUNNING", "INITIALIZING")
         copy_prefix = _byte_copy_prefix(info_lower)
         copied_label = (
             f"{copy_prefix}{format_bytes_compact(copied)} of {format_bytes_compact(total)}"
         )
 
-        return {
+        return _apply_summary_mongosync_version(
+            {
             "phase": phase,
             "copyPercent": copy_percent,
             "copyIndeterminate": copy_indeterminate,
             "copiedLabel": copied_label,
+            "copiedTitle": _copied_bytes_title(copied, total),
             "collectionsCopiedLabel": _build_collections_copied_label(metadata),
             "partitionsCopiedLabel": _build_partitions_copied_label(metadata),
-            "showCopyProgress": True,
+            "collectionsFinishedLabel": _build_collections_finished_label(
+                progress=progress, metadata=metadata, progress_available=True
+            ),
+            "showCopyProgress": copy_percent is not None or copy_indeterminate,
             "metrics": metrics,
-            "metadataMetrics": _build_metadata_metrics(metadata),
+            "metadataMetrics": _build_metadata_metrics(metadata, summary=summary),
             "phaseStartTimes": _build_phase_start_times(metadata),
-        }
+            },
+            summary=summary,
+            mongosync_version=mongosync_version,
+        )
 
     phase = _display_or_dash(metadata.get("phase") if metadata else None)
     phase_lower = (metadata.get("phase") or "").lower() if metadata else ""
@@ -330,33 +415,42 @@ def _build_sync_card(progress=None, metadata=None, *, progress_available=False):
     copied = metadata.get("copiedBytes") if metadata else None
     total = metadata.get("totalBytes") if metadata else None
 
-    copy_percent = None
+    copy_percent = _bytes_copy_percent(copied, total)
     copy_indeterminate = False
     copied_label = None
     show_copy_progress = False
 
     if total and total > 0 and copied is not None:
-        copy_percent = min(100.0, (copied / total) * 100)
         copy_prefix = _byte_copy_prefix(phase_lower)
         copied_label = (
             f"{copy_prefix}{format_bytes_compact(copied)} of {format_bytes_compact(total)}"
         )
+    if copy_percent is not None:
         show_copy_progress = True
     elif state in ("RUNNING", "INITIALIZING"):
         copy_indeterminate = True
+        show_copy_progress = True
 
-    return {
+    return _apply_summary_mongosync_version(
+        {
         "phase": phase,
         "copyPercent": copy_percent,
-        "copyIndeterminate": copy_indeterminate and not show_copy_progress,
+        "copyIndeterminate": copy_indeterminate,
         "copiedLabel": copied_label,
+        "copiedTitle": _copied_bytes_title(copied, total) if copied_label else None,
         "collectionsCopiedLabel": _build_collections_copied_label(metadata),
         "partitionsCopiedLabel": _build_partitions_copied_label(metadata),
+        "collectionsFinishedLabel": _build_collections_finished_label(
+            progress=progress, metadata=metadata, progress_available=progress_available
+        ),
         "showCopyProgress": show_copy_progress,
         "metrics": _build_db_only_metrics(lag_seconds),
-        "metadataMetrics": _build_metadata_metrics(metadata),
+        "metadataMetrics": _build_metadata_metrics(metadata, summary=summary),
         "phaseStartTimes": _build_phase_start_times(metadata),
-    }
+        },
+        summary=summary,
+        mongosync_version=mongosync_version,
+    )
 
 
 _INDEX_BUILDING_DESCRIPTION = (
@@ -396,7 +490,7 @@ def _build_index_building_card(
                 "small": True,
             },
             {
-                "label": "Collections finished",
+                "label": "Collections finished building indexes",
                 "value": f"{format_count(coll_finished)} / {format_count(coll_total)}",
                 "small": True,
             },
@@ -538,10 +632,7 @@ def _verification_side_kv(side_data):
                 side_data.get("estimatedDocumentCount"),
             ),
         },
-        {
-            "label": "Lag time",
-            "value": format_lag_time_seconds(side_data.get("lagTimeSeconds")),
-        },
+        _duration_metric("Lag time", side_data.get("lagTimeSeconds")),
     ]
 
 
@@ -689,7 +780,14 @@ def _build_toolbar_badges(progress, verification_card, index_card):
     return badges
 
 
-def _build_display(progress, metadata, *, progress_available=False):
+def _build_display(
+    progress,
+    metadata,
+    *,
+    progress_available=False,
+    summary=False,
+    mongosync_version=None,
+):
     if progress_available and progress:
         state = (progress.get("state") or "").upper() or "—"
         state_badge = _derive_state_badge(progress)
@@ -701,6 +799,8 @@ def _build_display(progress, metadata, *, progress_available=False):
         progress=progress,
         metadata=metadata,
         progress_available=progress_available,
+        summary=summary,
+        mongosync_version=mongosync_version,
     )
 
     display = {

--- a/migration/mongosync_insights/lib/live_monitoring.py
+++ b/migration/mongosync_insights/lib/live_monitoring.py
@@ -20,6 +20,7 @@ from .live_metadata_status import (
     normalize_verification_mode,
     should_suppress_index_build_progress,
     verification_progress_allowed,
+    is_during_or_after_cea,
 )
 from .utils import (
     format_bytes_compact,
@@ -281,11 +282,35 @@ def _byte_copy_prefix(phase_lower):
     return "Copied: "
 
 
-def _build_collections_copied_label(metadata):
-    if not metadata:
+def atlas_live_migrate_collection_totals(progress):
+    """Return collectionsCopied/collectionsTotal from progress.atlasLiveMigrateMetrics."""
+    if not isinstance(progress, dict):
         return None
-    copied = metadata.get("collectionsCopied")
-    total = metadata.get("collectionsTotal")
+    alm = progress.get("atlasLiveMigrateMetrics")
+    if not isinstance(alm, dict):
+        return None
+    total = alm.get("initialNumCollectionsTotal")
+    copied = alm.get("initialNumCollectionsCopied")
+    if total is None and copied is None:
+        return None
+    return {
+        "collectionsCopied": copied if copied is not None else 0,
+        "collectionsTotal": total,
+    }
+
+
+def _build_collections_copied_label(metadata, progress=None):
+    copied = None
+    total = None
+    atlas_totals = atlas_live_migrate_collection_totals(progress)
+    if atlas_totals and atlas_totals.get("collectionsTotal"):
+        copied = atlas_totals.get("collectionsCopied")
+        total = atlas_totals.get("collectionsTotal")
+    elif metadata:
+        copied = metadata.get("collectionsCopied")
+        total = metadata.get("collectionsTotal")
+    if not metadata and not atlas_totals:
+        return None
     if not total or total <= 0:
         return None
     if copied is None:
@@ -314,25 +339,7 @@ def _bytes_copy_percent(copied, total):
     return min(100.0, (copied / total) * 100)
 
 
-def _build_collections_finished_label(progress=None, metadata=None, *, progress_available=False):
-    coll_finished = None
-    coll_total = None
-    if progress_available and progress:
-        index_building = progress.get("indexBuilding") or {}
-        if isinstance(index_building, dict):
-            coll_finished = index_building.get("collectionsFinished")
-            coll_total = index_building.get("collectionsTotal")
-    if coll_total is None and metadata:
-        coll_finished = metadata.get("indexCollectionsFinished")
-        coll_total = metadata.get("indexCollectionsTotal")
-    if not coll_total or coll_total <= 0:
-        return None
-    if coll_finished is None:
-        coll_finished = 0
-    return f"Collections Copied: {format_count(coll_finished)} of {format_count(coll_total)}"
-
-
-def _build_phase_start_times(metadata):
+def _build_phase_start_times(metadata, *, summary=False):
     if not metadata:
         return None
     rows = metadata.get("phaseTransitions") or []
@@ -342,6 +349,7 @@ def _build_phase_start_times(metadata):
         "label": "Phase start times",
         "rows": rows,
         "timezoneNote": "UTC",
+        "timezoneNoteBelowTitle": summary,
     }
 
 
@@ -393,15 +401,12 @@ def _build_sync_card(
             "copyIndeterminate": copy_indeterminate,
             "copiedLabel": copied_label,
             "copiedTitle": _copied_bytes_title(copied, total),
-            "collectionsCopiedLabel": _build_collections_copied_label(metadata),
+            "collectionsCopiedLabel": _build_collections_copied_label(metadata, progress),
             "partitionsCopiedLabel": _build_partitions_copied_label(metadata),
-            "collectionsFinishedLabel": _build_collections_finished_label(
-                progress=progress, metadata=metadata, progress_available=True
-            ),
             "showCopyProgress": copy_percent is not None or copy_indeterminate,
             "metrics": metrics,
             "metadataMetrics": _build_metadata_metrics(metadata, summary=summary),
-            "phaseStartTimes": _build_phase_start_times(metadata),
+            "phaseStartTimes": _build_phase_start_times(metadata, summary=summary),
             },
             summary=summary,
             mongosync_version=mongosync_version,
@@ -438,15 +443,12 @@ def _build_sync_card(
         "copyIndeterminate": copy_indeterminate,
         "copiedLabel": copied_label,
         "copiedTitle": _copied_bytes_title(copied, total) if copied_label else None,
-        "collectionsCopiedLabel": _build_collections_copied_label(metadata),
+        "collectionsCopiedLabel": _build_collections_copied_label(metadata, progress),
         "partitionsCopiedLabel": _build_partitions_copied_label(metadata),
-        "collectionsFinishedLabel": _build_collections_finished_label(
-            progress=progress, metadata=metadata, progress_available=progress_available
-        ),
         "showCopyProgress": show_copy_progress,
         "metrics": _build_db_only_metrics(lag_seconds),
         "metadataMetrics": _build_metadata_metrics(metadata, summary=summary),
-        "phaseStartTimes": _build_phase_start_times(metadata),
+        "phaseStartTimes": _build_phase_start_times(metadata, summary=summary),
         },
         summary=summary,
         mongosync_version=mongosync_version,
@@ -696,7 +698,12 @@ def _resolve_verification_display(progress, metadata, *, progress_available=Fals
             if card:
                 return card
     if mode == "startAtCEA":
-        return _build_verification_info(metadata)
+        sync_phase = metadata.get("syncPhase") if metadata else None
+        if not sync_phase and progress:
+            sync_phase = (progress.get("info") or "").strip()
+        if not is_during_or_after_cea(sync_phase):
+            return _build_verification_info(metadata)
+        return None
     if progress_available and progress:
         return _build_verification(progress)
     return None
@@ -818,7 +825,7 @@ def _build_display(
     index_building = None
     if progress_available and progress:
         index_building = _build_index_building(progress)
-        if index_building and metadata and should_suppress_index_build_progress(
+        if index_building and metadata and not summary and should_suppress_index_build_progress(
             metadata.get("buildIndexesRaw"),
             metadata.get("syncPhase"),
         ):

--- a/migration/mongosync_insights/lib/log_summary.py
+++ b/migration/mongosync_insights/lib/log_summary.py
@@ -11,7 +11,7 @@ from .live_metadata_status import (
     namespace_filter_is_active,
     normalize_verification_mode,
 )
-from .live_monitoring import _build_display
+from .live_monitoring import _build_display, atlas_live_migrate_collection_totals
 
 _PAGE_TITLE = "Summary"
 _EMPTY_ERROR = (
@@ -347,6 +347,234 @@ def merge_state_transitions_into_progress(progress, state_transitions, phase_eve
     return out
 
 
+def _log_time_sort_key(raw):
+    if not raw:
+        return ""
+    return str(raw).strip().replace("Z", "")[:26]
+
+
+class SummaryMigrationState:
+    """Track latest Summary migration phase/state/index progress from log events."""
+
+    def __init__(self):
+        self.progress_snapshot = None
+        self.progress_time = None
+        self.phase = None
+        self.phase_time = None
+        self.state = None
+        self.state_time = None
+        self.index_building = None
+        self.index_building_time = None
+        self.verification = None
+        self.verification_time = None
+        self.total_events_applied_peak = None
+        self.total_events_applied_last_positive = None
+
+    def note_progress(self, progress, time):
+        if not isinstance(progress, dict):
+            return
+        stamp = _log_time_sort_key(time)
+        if not stamp:
+            return
+        self.progress_snapshot = dict(progress)
+        self.progress_time = stamp
+        self.note_phase(progress.get("info"), time)
+        self.note_state(progress.get("state"), time)
+        index_building = _normalize_index_building(progress.get("indexBuilding"))
+        if index_building:
+            self.note_index_building(index_building, time)
+        verification = _normalize_verification(progress.get("verification"))
+        if verification:
+            self.note_verification(verification, time)
+        self.note_events_applied(progress.get("totalEventsApplied"), time)
+        atlas_events = _events_applied_from_atlas_progress(progress)
+        if atlas_events is not None:
+            self.note_events_applied(atlas_events, time)
+
+    def note_phase(self, phase, time):
+        if not phase:
+            return
+        stamp = _log_time_sort_key(time)
+        if not stamp:
+            return
+        if self.phase_time is None or stamp >= self.phase_time:
+            self.phase = str(phase).strip()
+            self.phase_time = stamp
+
+    def note_state(self, state, time):
+        if not state:
+            return
+        stamp = _log_time_sort_key(time)
+        if not stamp:
+            return
+        if self.state_time is None or stamp >= self.state_time:
+            self.state = str(state).strip().upper()
+            self.state_time = stamp
+
+    def note_index_building(self, index_building, time):
+        normalized = _normalize_index_building(index_building)
+        if not normalized:
+            return
+        stamp = _log_time_sort_key(time)
+        if not stamp:
+            if self.index_building is None:
+                self.index_building = normalized
+            return
+        if self.index_building_time is None or stamp >= self.index_building_time:
+            self.index_building = normalized
+            self.index_building_time = stamp
+
+    def note_verification(self, verification, time):
+        if not verification:
+            return
+        stamp = _log_time_sort_key(time)
+        if not stamp:
+            if self.verification is None:
+                self.verification = verification
+            return
+        if self.verification_time is None or stamp >= self.verification_time:
+            self.verification = verification
+            self.verification_time = stamp
+
+    def note_events_applied(self, value, time):
+        coerced = _coerce_event_count(value)
+        if coerced is None:
+            return
+        if self.total_events_applied_peak is None or coerced > self.total_events_applied_peak:
+            self.total_events_applied_peak = coerced
+        if coerced > 0:
+            self.total_events_applied_last_positive = coerced
+
+    def to_progress(
+        self,
+        *,
+        replication_lines=None,
+        state_transitions=None,
+        phase_events=None,
+        sent_responses=None,
+    ):
+        out = dict(self.progress_snapshot) if self.progress_snapshot else {}
+        if self.phase:
+            out["info"] = self.phase
+        if self.state:
+            out["state"] = self.state
+        if self.index_building:
+            out["indexBuilding"] = self.index_building
+        if self.verification:
+            out["verification"] = self.verification
+
+        out = merge_state_transitions_into_progress(
+            out or None, state_transitions, phase_events
+        )
+        out = merge_replication_into_progress(out, replication_lines)
+        out = merge_events_applied_into_progress(
+            out,
+            replication_lines=replication_lines,
+            sent_responses=sent_responses,
+            tracked_peak=self.total_events_applied_last_positive
+            or self.total_events_applied_peak,
+        )
+        out = backfill_commit_events_applied(
+            out,
+            replication_lines,
+            sent_responses=sent_responses,
+            tracked_peak=self.total_events_applied_last_positive
+            or self.total_events_applied_peak,
+        )
+        if out and not out.get("info") and phase_events:
+            out["info"] = phase_events[-1][1]
+        return out or None
+
+
+def build_summary_migration_state(
+    *,
+    progress=None,
+    progress_time=None,
+    sent_responses=None,
+    phase_events=None,
+    state_transitions=None,
+    index_creation_lines=None,
+):
+    """Replay log-derived events into a single Summary migration state tracker."""
+    state = SummaryMigrationState()
+
+    for response in sent_responses or []:
+        if not isinstance(response, dict):
+            continue
+        try:
+            parsed_body = json.loads(response.get("body") or "{}")
+        except (json.JSONDecodeError, TypeError):
+            continue
+        response_progress = (parsed_body or {}).get("progress")
+        if isinstance(response_progress, dict):
+            state.note_progress(response_progress, response.get("time"))
+
+    if progress and not sent_responses:
+        if progress_time:
+            state.note_progress(progress, progress_time)
+        else:
+            state.progress_snapshot = dict(progress)
+            if progress.get("info"):
+                state.phase = str(progress["info"]).strip()
+            if progress.get("state"):
+                state.state = str(progress["state"]).strip().upper()
+            index_building = _normalize_index_building(progress.get("indexBuilding"))
+            if index_building:
+                state.index_building = index_building
+
+    for raw_time, label in phase_events or []:
+        state.note_phase(label, raw_time)
+
+    for item in state_transitions or []:
+        if not isinstance(item, dict):
+            continue
+        new_state = (item.get("newState") or "").strip().upper()
+        if new_state:
+            state.note_state(new_state, item.get("time"))
+
+    for item in index_creation_lines or []:
+        if not isinstance(item, dict):
+            continue
+        state.note_index_building(item.get("indexCreationProgress"), item.get("time"))
+
+    return state
+
+
+def merge_state_transitions_into_progress(progress, state_transitions, phase_events=None):
+    """Overlay COMMITTED state and final phase when logs continue after the last /progress."""
+    if not progress:
+        return progress
+    committed = _latest_committed_state_transition(state_transitions)
+    if not committed:
+        return progress
+    committed_time = (committed.get("time") or "")[:26]
+    out = dict(progress)
+    out["state"] = "COMMITTED"
+    out["info"] = (
+        _phase_after_committed(phase_events, committed_time) or "commit completed"
+    )
+    return out
+
+
+def merge_phase_events_into_progress(progress, phase_events, *, progress_time=None):
+    """Overlay newer phase labels from log events when /progress is stale (Summary)."""
+    if not progress or not phase_events:
+        return progress
+    if (progress.get("state") or "").upper() == "COMMITTED":
+        return progress
+    last_time, last_label = phase_events[-1]
+    if not last_label or not last_time:
+        return progress
+    if progress_time and _log_time_sort_key(last_time) <= _log_time_sort_key(progress_time):
+        return progress
+    current = (progress.get("info") or "").strip().lower()
+    if current == (last_label or "").strip().lower():
+        return progress
+    out = dict(progress)
+    out["info"] = last_label
+    return out
+
+
 def _resolve_finish_time(phase_rows, state_transitions):
     committed = _committed_time_from_state_transitions(state_transitions)
     if committed:
@@ -356,17 +584,318 @@ def _resolve_finish_time(phase_rows, state_transitions):
 
 
 def merge_replication_into_progress(progress, replication_lines):
-    """Fill lag / events / oplog window from the last Replication progress log line."""
+    """Fill lag / oplog window from Replication progress log lines."""
     if not replication_lines:
         return dict(progress) if progress else None
     last = replication_lines[-1] if isinstance(replication_lines[-1], dict) else {}
     out = dict(progress) if progress else {}
     if out.get("lagTimeSeconds") is None and last.get("lagTimeSeconds") is not None:
         out["lagTimeSeconds"] = last["lagTimeSeconds"]
-    if out.get("totalEventsApplied") is None and last.get("totalEventsApplied") is not None:
-        out["totalEventsApplied"] = last["totalEventsApplied"]
     if not out.get("estimatedOplogTimeRemaining") and last.get("estimatedOplogTimeRemaining"):
         out["estimatedOplogTimeRemaining"] = last["estimatedOplogTimeRemaining"]
+    return out or None
+
+
+def _coerce_event_count(value):
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return int(value)
+    if isinstance(value, str):
+        stripped = value.strip().replace(",", "")
+        if not stripped:
+            return None
+        try:
+            return int(float(stripped))
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _events_applied_from_atlas_progress(progress):
+    if not isinstance(progress, dict):
+        return None
+    alm = progress.get("atlasLiveMigrateMetrics")
+    if not isinstance(alm, dict):
+        return None
+    crud = _coerce_event_count(alm.get("totalCRUDEventsApplied"))
+    ddl = _coerce_event_count(alm.get("totalDDLEventsApplied"))
+    if crud is None and ddl is None:
+        return None
+    return (crud or 0) + (ddl or 0)
+
+
+def _scan_events_applied_from_items(items, *, key="totalEventsApplied"):
+    latest_numeric = None
+    latest_positive = None
+    for item in items or []:
+        if not isinstance(item, dict):
+            continue
+        value = _coerce_event_count(item.get(key))
+        if value is None:
+            continue
+        latest_numeric = value
+        if value > 0:
+            latest_positive = value
+    if latest_positive is not None:
+        return latest_positive
+    return latest_numeric
+
+
+def _scan_events_applied_from_sent_responses(sent_responses):
+    latest_numeric = None
+    latest_positive = None
+    for response in sent_responses or []:
+        if not isinstance(response, dict):
+            continue
+        try:
+            parsed_body = json.loads(response.get("body") or "{}")
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if not isinstance(parsed_body, dict):
+            continue
+        progress = parsed_body.get("progress")
+        if not isinstance(progress, dict):
+            continue
+        for value in (
+            _coerce_event_count(progress.get("totalEventsApplied")),
+            _events_applied_from_atlas_progress(progress),
+        ):
+            if value is None:
+                continue
+            latest_numeric = value
+            if value > 0:
+                latest_positive = value
+    if latest_positive is not None:
+        return latest_positive
+    return latest_numeric
+
+
+def _best_known_events_applied(
+    replication_lines=None,
+    sent_responses=None,
+    *,
+    tracked_peak=None,
+):
+    candidates = [
+        _scan_events_applied_from_items(replication_lines),
+        _scan_events_applied_from_sent_responses(sent_responses),
+        _coerce_event_count(tracked_peak),
+    ]
+    latest_positive = None
+    latest_numeric = None
+    for value in candidates:
+        coerced = _coerce_event_count(value)
+        if coerced is None:
+            continue
+        latest_numeric = coerced
+        if coerced > 0:
+            latest_positive = coerced
+    if latest_positive is not None:
+        return latest_positive
+    return latest_numeric
+
+
+def merge_events_applied_into_progress(
+    progress,
+    *,
+    replication_lines=None,
+    sent_responses=None,
+    tracked_peak=None,
+):
+    """Fill totalEventsApplied from replication, /progress history, and tracked peaks."""
+    out = dict(progress) if progress else {}
+    current = _coerce_event_count(out.get("totalEventsApplied"))
+    if current not in (None, 0):
+        return out or None
+    resolved = _best_known_events_applied(
+        replication_lines,
+        sent_responses,
+        tracked_peak=tracked_peak,
+    )
+    if resolved is None:
+        atlas_events = _events_applied_from_atlas_progress(out)
+        if atlas_events is not None:
+            resolved = atlas_events
+    if resolved is not None:
+        out["totalEventsApplied"] = resolved
+    return out or None
+
+
+def _last_known_events_applied(replication_lines):
+    """Return best-known totalEventsApplied from replication logs."""
+    return _scan_events_applied_from_items(replication_lines)
+
+
+_LATE_COMMIT_PHASES = frozenset(
+    {
+        "commit completed",
+        "waiting for index constraint enablement at the end of commit",
+        "waiting for commit to complete",
+    }
+)
+
+
+def _is_late_commit_phase(phase):
+    normalized = (phase or "").strip().lower().rstrip(".")
+    if normalized in _LATE_COMMIT_PHASES:
+        return True
+    return "commit" in normalized and "collection copy" not in normalized
+
+
+def backfill_commit_events_applied(
+    progress,
+    replication_lines,
+    *,
+    sent_responses=None,
+    tracked_peak=None,
+):
+    """Keep Events applied from dropping to 0 on late commit phases in Summary."""
+    if not progress:
+        return progress
+    phase = (progress.get("info") or "").strip().lower()
+    if not _is_late_commit_phase(phase):
+        return progress
+    current = _coerce_event_count(progress.get("totalEventsApplied"))
+    if current not in (None, 0):
+        return progress
+    last_known = _best_known_events_applied(
+        replication_lines,
+        sent_responses,
+        tracked_peak=tracked_peak,
+    )
+    if last_known is None or last_known == current:
+        return progress
+    out = dict(progress)
+    out["totalEventsApplied"] = last_known
+    return out
+
+
+def _normalize_verification(verification):
+    """Normalize progress.verification from /progress sent-response payloads."""
+    if not verification or not isinstance(verification, dict):
+        return None
+    source = verification.get("source")
+    destination = verification.get("destination")
+    if not source and not destination:
+        return None
+    out = {}
+    if isinstance(source, dict):
+        out["source"] = source
+    if isinstance(destination, dict):
+        out["destination"] = destination
+    return out or None
+
+
+def extract_latest_verification_from_sent_responses(responses):
+    """Return the last progress.verification block from sent-response bodies."""
+    latest = None
+    for response in responses or []:
+        if not isinstance(response, dict):
+            continue
+        try:
+            parsed_body = json.loads(response.get("body") or "{}")
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if not isinstance(parsed_body, dict):
+            continue
+        progress = parsed_body.get("progress")
+        if not isinstance(progress, dict):
+            continue
+        verification = _normalize_verification(progress.get("verification"))
+        if verification:
+            latest = verification
+    return latest
+
+
+def merge_verification_into_progress(progress, *, sent_responses=None):
+    """Backfill verification when the latest /progress omits it (Summary tab)."""
+    out = dict(progress) if progress else {}
+    current = _normalize_verification(out.get("verification"))
+    if current:
+        out["verification"] = current
+        return out or None
+    backfill = extract_latest_verification_from_sent_responses(sent_responses)
+    if backfill:
+        out["verification"] = backfill
+    return out or None
+
+
+def _normalize_index_building(index_building):
+    """Normalize indexBuilding from /progress or Index creation progress logs."""
+    if not index_building or not isinstance(index_building, dict):
+        return None
+    total = index_building.get("totalIndexesToBuild")
+    coll_total = index_building.get("collectionsTotal")
+    if coll_total is None:
+        coll_total = index_building.get("totalCollections")
+    built = index_building.get("indexesBuilt")
+    if built is None:
+        built = index_building.get("totalIndexesBuilt")
+    coll_finished = index_building.get("collectionsFinished")
+    if coll_finished is None:
+        coll_finished = index_building.get("finishedCollections")
+    if not total and not coll_total:
+        return None
+    return {
+        "indexesBuilt": built or 0,
+        "totalIndexesToBuild": total or 0,
+        "collectionsFinished": coll_finished or 0,
+        "collectionsTotal": coll_total or 0,
+    }
+
+
+def extract_latest_index_building_from_sent_responses(responses):
+    """Return the last indexBuilding block from sent-response /progress payloads."""
+    latest = None
+    for response in responses or []:
+        if not isinstance(response, dict):
+            continue
+        try:
+            parsed_body = json.loads(response.get("body") or "{}")
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if not isinstance(parsed_body, dict):
+            continue
+        progress = parsed_body.get("progress")
+        if not isinstance(progress, dict):
+            continue
+        normalized = _normalize_index_building(progress.get("indexBuilding"))
+        if normalized:
+            latest = normalized
+    return latest
+
+
+def extract_latest_index_creation_progress(index_creation_lines):
+    """Return index building totals from the last Index creation progress log line."""
+    latest = None
+    for item in index_creation_lines or []:
+        if not isinstance(item, dict):
+            continue
+        normalized = _normalize_index_building(item.get("indexCreationProgress"))
+        if normalized:
+            latest = normalized
+    return latest
+
+
+def merge_index_building_into_progress(
+    progress,
+    *,
+    sent_responses=None,
+    index_creation_lines=None,
+):
+    """Backfill indexBuilding when the latest /progress omits it (Summary tab)."""
+    out = dict(progress) if progress else {}
+    current = _normalize_index_building(out.get("indexBuilding"))
+    if current:
+        out["indexBuilding"] = current
+        return out or None
+
+    backfill = extract_latest_index_building_from_sent_responses(
+        sent_responses
+    ) or extract_latest_index_creation_progress(index_creation_lines)
+    if backfill:
+        out["indexBuilding"] = backfill
     return out or None
 
 
@@ -412,6 +941,13 @@ def build_log_metadata(
         "exclusionFilter": exclusion,
     }
 
+    collections_copied = None
+    collections_total_out = collections_total if collections_total else None
+    atlas_totals = atlas_live_migrate_collection_totals(progress)
+    if atlas_totals and atlas_totals.get("collectionsTotal"):
+        collections_copied = atlas_totals.get("collectionsCopied")
+        collections_total_out = atlas_totals.get("collectionsTotal")
+
     metadata = {
         "state": (progress.get("state") if progress else None),
         "phase": (sync_phase.capitalize() if sync_phase else None),
@@ -424,8 +960,8 @@ def build_log_metadata(
         "buildIndexes": format_build_indexes(build_indexes_raw),
         "verificationModeRaw": _verification_mode_from_start(start_options),
         "detectRandomId": detect_random_id,
-        "collectionsCopied": None,
-        "collectionsTotal": collections_total if collections_total else None,
+        "collectionsCopied": collections_copied,
+        "collectionsTotal": collections_total_out,
         "partitionsCopied": partitions_copied,
         "partitionsTotal": partitions_total,
         "phaseTransitions": phase_rows,
@@ -493,15 +1029,31 @@ def build_log_summary_payload(
     partitions_total=None,
     collections_total=None,
     version_info_lines=None,
+    sent_responses=None,
+    index_creation_lines=None,
+    summary_state=None,
 ):
     """Build the live-monitor JSON payload for the Log Analyzer Summary tab."""
-    from_progress_api = bool(progress)
-    merged_progress = merge_replication_into_progress(progress, replication_lines)
-    merged_progress = merge_state_transitions_into_progress(
-        merged_progress, state_transitions, phase_events
+    from_progress_api = bool(progress or (summary_state and summary_state.progress_snapshot))
+    if summary_state is None:
+        summary_state = build_summary_migration_state(
+            progress=progress,
+            progress_time=progress_time,
+            sent_responses=sent_responses,
+            phase_events=phase_events,
+            state_transitions=state_transitions,
+            index_creation_lines=index_creation_lines,
+        )
+    merged_progress = summary_state.to_progress(
+        replication_lines=replication_lines,
+        state_transitions=state_transitions,
+        phase_events=phase_events,
+        sent_responses=sent_responses,
     )
-    if merged_progress and not merged_progress.get("info") and phase_events:
-        merged_progress["info"] = phase_events[-1][1]
+    merged_progress = merge_verification_into_progress(
+        merged_progress,
+        sent_responses=sent_responses,
+    )
 
     metadata = build_log_metadata(
         progress=merged_progress,

--- a/migration/mongosync_insights/lib/log_summary.py
+++ b/migration/mongosync_insights/lib/log_summary.py
@@ -1,0 +1,558 @@
+"""Build a Migration Monitoring-style Summary payload from parsed mongosync logs."""
+
+import json
+from collections import OrderedDict
+
+from .data_sources import STATUS_ACTIVE, build_data_sources
+from .live_metadata_status import (
+    format_build_indexes,
+    format_namespace_filter_rows,
+    format_write_blocking_mode,
+    namespace_filter_is_active,
+    normalize_verification_mode,
+)
+from .live_monitoring import _build_display
+
+_PAGE_TITLE = "Summary"
+_EMPTY_ERROR = (
+    "No /progress payload or other summary fields were found in this log. "
+    "Include log lines that record mongosync HTTP responses to /api/v1/progress, "
+    "or the startup /start request and phase-transition messages."
+)
+
+_FINISH_PHASE_NEEDLES = (
+    "commit handler called",
+    "commit completed",
+    "committed",
+)
+
+
+def extract_latest_progress(responses):
+    """Return (progress dict, log time) from the last sent-response body that contains progress."""
+    latest = None
+    latest_time = None
+    for response in responses or []:
+        if not isinstance(response, dict):
+            continue
+        try:
+            parsed_body = json.loads(response.get("body") or "{}")
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if not isinstance(parsed_body, dict):
+            continue
+        progress = parsed_body.get("progress")
+        if not isinstance(progress, dict) or not progress:
+            continue
+        latest = progress
+        latest_time = response.get("time")
+    return latest, latest_time
+
+
+def extract_mongosync_version(version_info_lines):
+    """Return mongosync version from the first log line with message 'Version info'."""
+    for item in version_info_lines or []:
+        if not isinstance(item, dict):
+            continue
+        version = item.get("version")
+        if version not in (None, ""):
+            return str(version)
+    return None
+
+
+def format_log_timestamp(raw):
+    """Convert a mongosync log time string to 'YYYY-MM-DD HH:MM:SS'."""
+    if not raw:
+        return None
+    text = str(raw).strip().replace("T", " ")
+    if text.endswith("Z"):
+        text = text[:-1]
+    if len(text) >= 19 and text[4] == "-" and text[10] == " ":
+        return text[:19]
+    return text or None
+
+
+def phase_transition_rows_from_events(phase_events):
+    """Convert merged (time, label) phase events to live-monitor phase start rows."""
+    rows = []
+    for item in phase_events or []:
+        if not item or len(item) < 2:
+            continue
+        raw_time, label = item[0], item[1]
+        phase = (label or "").strip()
+        if not phase:
+            continue
+        rows.append(
+            {
+                "phase": phase.capitalize(),
+                "startedAt": format_log_timestamp(raw_time) or "—",
+            }
+        )
+    return rows
+
+
+def natural_order_rows_from_log(items):
+    """Group {database, collection} log rows into live-monitor natural-order rows."""
+    if not items:
+        return None
+    by_db = OrderedDict()
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        db = item.get("database") or "—"
+        coll = item.get("collection") or "—"
+        by_db.setdefault(db, [])
+        if coll not in by_db[db]:
+            by_db[db].append(coll)
+    if not by_db:
+        return None
+    return [
+        {"database": db, "collections": ", ".join(colls)}
+        for db, colls in by_db.items()
+    ]
+
+
+def _first_dict(items):
+    if items and isinstance(items[0], dict):
+        return items[0]
+    if isinstance(items, dict):
+        return items
+    return {}
+
+
+def _normalize_namespace_entries(entries):
+    if not entries or not isinstance(entries, list):
+        return None
+    normalized = []
+    for item in entries:
+        if not isinstance(item, dict):
+            continue
+        database = item.get("database")
+        collections = item.get("collections")
+        if isinstance(database, str):
+            database = [database]
+        normalized.append({"database": database, "collections": collections})
+    return normalized or None
+
+
+def _last_dict(items):
+    if not items:
+        return {}
+    last = items[-1]
+    return last if isinstance(last, dict) else {}
+
+
+def _write_blocking_raw(start_options):
+    if not start_options:
+        return None
+    value = start_options.get("enableUserWriteBlocking")
+    if value is True:
+        return "sourceAndDestination"
+    if value is False:
+        return "none"
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def _disable_write_blocking_from_hidden_flags(hidden_flags):
+    """Read disableWriteBlocking from a Mongosync HiddenFlags log object."""
+    flags = _first_dict(hidden_flags) if not isinstance(hidden_flags, dict) else hidden_flags
+    if not flags:
+        return None
+    other = flags.get("other")
+    if isinstance(other, dict) and "disableWriteBlocking" in other:
+        return other.get("disableWriteBlocking")
+    if "disableWriteBlocking" in flags:
+        return flags.get("disableWriteBlocking")
+    return None
+
+
+def _write_blocking_mode_from_hidden_flags(hidden_flags):
+    """Map HiddenFlags disableWriteBlocking to Summary display text."""
+    value = _disable_write_blocking_from_hidden_flags(hidden_flags)
+    if value is False:
+        return "Default"
+    if value is True:
+        return "Disabled"
+    return None
+
+
+def _build_indexes_raw_from_start_handler(start_handler_parameters):
+    """Resolve buildIndexes from Start handler called parameters."""
+    params = _last_dict(start_handler_parameters)
+    if not params:
+        return None
+    if "BuildIndexes" not in params:
+        return None
+    value = params.get("BuildIndexes")
+    if value is None:
+        return "afterDataCopy"
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _resolve_build_indexes_raw(start_options, hidden_flags, start_handler_parameters):
+    from_handler = _build_indexes_raw_from_start_handler(start_handler_parameters)
+    if from_handler is not None:
+        return from_handler
+    return _lookup_option(start_options, hidden_flags, "buildIndexes")
+
+
+def _detect_random_id_from_start_handler(start_handler_parameters):
+    """Resolve DetectRandomId from Start handler called parameters."""
+    params = _last_dict(start_handler_parameters)
+    if not params or "DetectRandomId" not in params:
+        return None
+    value = params.get("DetectRandomId")
+    if value is False:
+        return "False"
+    if value is None or value is True:
+        return "True"
+    return str(value)
+
+
+def _resolve_detect_random_id(start_options, hidden_flags, start_handler_parameters):
+    from_handler = _detect_random_id_from_start_handler(start_handler_parameters)
+    if from_handler is not None:
+        return from_handler
+    raw = _lookup_option(start_options, hidden_flags, "detectRandomId")
+    return str(raw) if raw is not None else None
+
+
+def _reversible_from_start_handler(start_handler_parameters):
+    """Resolve Reversible from Start handler called parameters."""
+    params = _last_dict(start_handler_parameters)
+    if not params or "Reversible" not in params:
+        return None
+    value = params.get("Reversible")
+    if value is True:
+        return "True"
+    if value is False:
+        return "False"
+    return str(value) if value is not None else None
+
+
+def _resolve_reversible(start_options, hidden_flags, start_handler_parameters):
+    from_handler = _reversible_from_start_handler(start_handler_parameters)
+    if from_handler is not None:
+        return from_handler
+    raw = _lookup_option(start_options, hidden_flags, "reversible")
+    return str(raw) if raw is not None else None
+
+
+def _resolve_write_blocking_mode(start_options, hidden_flags):
+    from_hidden = _write_blocking_mode_from_hidden_flags(hidden_flags)
+    if from_hidden is not None:
+        return from_hidden
+    return format_write_blocking_mode(_write_blocking_raw(start_options))
+
+
+def _verification_mode_from_start(start_options):
+    if not start_options:
+        return None
+    if start_options.get("enableVerifier") is False:
+        return "disabled"
+    verification = start_options.get("verification")
+    if verification is False:
+        return "disabled"
+    if isinstance(verification, dict):
+        enabled = verification.get("enabled")
+        if enabled is None:
+            enabled = verification.get("enableVerifier")
+        if enabled is False:
+            return "disabled"
+        raw_mode = verification.get("mode") or verification.get("verificationMode")
+        if raw_mode:
+            return normalize_verification_mode(raw_mode)
+        if enabled is True:
+            return "startAtCEA"
+    return None
+
+
+def _lookup_option(start_options, hidden_flags, key):
+    if start_options and start_options.get(key) is not None:
+        return start_options.get(key)
+    if hidden_flags and hidden_flags.get(key) is not None:
+        return hidden_flags.get(key)
+    return None
+
+
+def _start_finish_from_phases(rows):
+    start = None
+    finish = None
+    for row in rows or []:
+        phase_lower = (row.get("phase") or "").lower()
+        if start is None and "initializing collections" in phase_lower:
+            start = row.get("startedAt")
+        if any(needle in phase_lower for needle in _FINISH_PHASE_NEEDLES):
+            finish = row.get("startedAt")
+    if start is None and rows:
+        start = rows[0].get("startedAt")
+    return start, finish
+
+
+def _committed_time_from_state_transitions(state_transitions):
+    """Return formatted commit time from the latest COMMITTED state transition log line."""
+    transition = _latest_committed_state_transition(state_transitions)
+    if not transition:
+        return None
+    return format_log_timestamp(transition.get("time"))
+
+
+def _latest_committed_state_transition(state_transitions):
+    """Return the latest log object where newState is COMMITTED."""
+    latest = None
+    latest_time = None
+    for item in state_transitions or []:
+        if not isinstance(item, dict):
+            continue
+        new_state = (item.get("newState") or "").strip().upper()
+        if new_state != "COMMITTED":
+            continue
+        raw_time = (item.get("time") or "")[:26]
+        if not raw_time:
+            continue
+        if latest_time is None or raw_time > latest_time:
+            latest_time = raw_time
+            latest = item
+    return latest
+
+
+def _phase_after_committed(phase_events, committed_time):
+    """Return the latest phase label at or after the COMMITTED state transition."""
+    if not phase_events or not committed_time:
+        return None
+    for raw_time, label in reversed(phase_events):
+        if raw_time >= committed_time:
+            phase = (label or "").strip()
+            if phase:
+                return phase
+    return None
+
+
+def merge_state_transitions_into_progress(progress, state_transitions, phase_events=None):
+    """Overlay COMMITTED state and final phase when logs continue after the last /progress."""
+    if not progress:
+        return progress
+    committed = _latest_committed_state_transition(state_transitions)
+    if not committed:
+        return progress
+    committed_time = (committed.get("time") or "")[:26]
+    out = dict(progress)
+    out["state"] = "COMMITTED"
+    out["info"] = (
+        _phase_after_committed(phase_events, committed_time) or "commit completed"
+    )
+    return out
+
+
+def _resolve_finish_time(phase_rows, state_transitions):
+    committed = _committed_time_from_state_transitions(state_transitions)
+    if committed:
+        return committed
+    _start, finish = _start_finish_from_phases(phase_rows)
+    return finish
+
+
+def merge_replication_into_progress(progress, replication_lines):
+    """Fill lag / events / oplog window from the last Replication progress log line."""
+    if not replication_lines:
+        return dict(progress) if progress else None
+    last = replication_lines[-1] if isinstance(replication_lines[-1], dict) else {}
+    out = dict(progress) if progress else {}
+    if out.get("lagTimeSeconds") is None and last.get("lagTimeSeconds") is not None:
+        out["lagTimeSeconds"] = last["lagTimeSeconds"]
+    if out.get("totalEventsApplied") is None and last.get("totalEventsApplied") is not None:
+        out["totalEventsApplied"] = last["totalEventsApplied"]
+    if not out.get("estimatedOplogTimeRemaining") and last.get("estimatedOplogTimeRemaining"):
+        out["estimatedOplogTimeRemaining"] = last["estimatedOplogTimeRemaining"]
+    return out or None
+
+
+def build_log_metadata(
+    *,
+    progress=None,
+    phase_events=None,
+    natural_order_items=None,
+    start_options=None,
+    hidden_flags=None,
+    start_handler_parameters=None,
+    state_transitions=None,
+    partitions_copied=None,
+    partitions_total=None,
+    collections_total=None,
+):
+    """Build a live-monitor metadata dict from log-derived fields."""
+    start_options = _first_dict(start_options)
+    hidden_flags = _first_dict(hidden_flags)
+    phase_rows = phase_transition_rows_from_events(phase_events)
+    start, _phase_finish = _start_finish_from_phases(phase_rows)
+    finish = _resolve_finish_time(phase_rows, state_transitions)
+
+    sync_phase = None
+    if progress:
+        sync_phase = (progress.get("info") or "").strip().lower() or None
+    if not sync_phase and phase_events:
+        sync_phase = (phase_events[-1][1] or "").strip().lower() or None
+
+    build_indexes_raw = _resolve_build_indexes_raw(
+        start_options, hidden_flags, start_handler_parameters
+    )
+    reversible = _resolve_reversible(start_options, hidden_flags, start_handler_parameters)
+    detect_random_id = _resolve_detect_random_id(
+        start_options, hidden_flags, start_handler_parameters
+    )
+    write_blocking_mode = _resolve_write_blocking_mode(start_options, hidden_flags)
+
+    inclusion = _normalize_namespace_entries(start_options.get("includeNamespaces"))
+    exclusion = _normalize_namespace_entries(start_options.get("excludeNamespaces"))
+    namespace_filter = {
+        "inclusionFilter": inclusion,
+        "exclusionFilter": exclusion,
+    }
+
+    metadata = {
+        "state": (progress.get("state") if progress else None),
+        "phase": (sync_phase.capitalize() if sync_phase else None),
+        "syncPhase": sync_phase,
+        "start": start,
+        "finish": finish,
+        "reversible": reversible,
+        "writeBlockingMode": write_blocking_mode,
+        "buildIndexesRaw": build_indexes_raw,
+        "buildIndexes": format_build_indexes(build_indexes_raw),
+        "verificationModeRaw": _verification_mode_from_start(start_options),
+        "detectRandomId": detect_random_id,
+        "collectionsCopied": None,
+        "collectionsTotal": collections_total if collections_total else None,
+        "partitionsCopied": partitions_copied,
+        "partitionsTotal": partitions_total,
+        "phaseTransitions": phase_rows,
+        "naturalOrderRows": natural_order_rows_from_log(natural_order_items),
+        "namespaceFilterActive": namespace_filter_is_active(namespace_filter),
+        "inclusionFilterRows": format_namespace_filter_rows(inclusion, "inclusion"),
+        "exclusionFilterRows": format_namespace_filter_rows(exclusion, "exclusion"),
+    }
+    return metadata
+
+
+def _metadata_is_useful(metadata):
+    if not metadata:
+        return False
+    return any(
+        (
+            metadata.get("phaseTransitions"),
+            metadata.get("naturalOrderRows"),
+            metadata.get("namespaceFilterActive"),
+            metadata.get("reversible") is not None,
+            metadata.get("buildIndexesRaw"),
+            metadata.get("writeBlockingMode"),
+            metadata.get("verificationModeRaw"),
+            metadata.get("partitionsTotal"),
+            metadata.get("collectionsTotal"),
+            metadata.get("start"),
+        )
+    )
+
+
+def _page_subtitle(progress_time, *, from_progress_api):
+    as_of = format_log_timestamp(progress_time)
+    if as_of and from_progress_api:
+        return f"As of {as_of} UTC · latest /progress in this log (not live)"
+    if as_of:
+        return f"As of {as_of} UTC · snapshot from this log (not live)"
+    return "Snapshot from this log (not live)"
+
+
+def empty_log_summary_payload(*, error=None):
+    return {
+        "warnings": [],
+        "dataSources": None,
+        "progressWarning": None,
+        "metadataWarning": None,
+        "display": None,
+        "error": error or _EMPTY_ERROR,
+        "pageTitle": _PAGE_TITLE,
+        "pageSubtitle": "Snapshot from this log (not live)",
+    }
+
+
+def build_log_summary_payload(
+    *,
+    progress=None,
+    progress_time=None,
+    replication_lines=None,
+    phase_events=None,
+    natural_order_items=None,
+    start_options=None,
+    hidden_flags=None,
+    start_handler_parameters=None,
+    state_transitions=None,
+    partitions_copied=None,
+    partitions_total=None,
+    collections_total=None,
+    version_info_lines=None,
+):
+    """Build the live-monitor JSON payload for the Log Analyzer Summary tab."""
+    from_progress_api = bool(progress)
+    merged_progress = merge_replication_into_progress(progress, replication_lines)
+    merged_progress = merge_state_transitions_into_progress(
+        merged_progress, state_transitions, phase_events
+    )
+    if merged_progress and not merged_progress.get("info") and phase_events:
+        merged_progress["info"] = phase_events[-1][1]
+
+    metadata = build_log_metadata(
+        progress=merged_progress,
+        phase_events=phase_events,
+        natural_order_items=natural_order_items,
+        start_options=start_options,
+        hidden_flags=hidden_flags,
+        start_handler_parameters=start_handler_parameters,
+        state_transitions=state_transitions,
+        partitions_copied=partitions_copied,
+        partitions_total=partitions_total,
+        collections_total=collections_total,
+    )
+    metadata_useful = _metadata_is_useful(metadata)
+    progress_available = bool(merged_progress)
+
+    if not progress_available and not metadata_useful:
+        return empty_log_summary_payload()
+
+    as_of = progress_time
+    if not as_of and replication_lines:
+        last = replication_lines[-1]
+        if isinstance(last, dict):
+            as_of = last.get("time")
+
+    warnings = []
+    if progress_available and isinstance(merged_progress.get("warnings"), list):
+        warnings = merged_progress.get("warnings") or []
+
+    display = _build_display(
+        merged_progress if progress_available else None,
+        metadata if metadata_useful else None,
+        progress_available=progress_available,
+        summary=True,
+        mongosync_version=extract_mongosync_version(version_info_lines),
+    )
+
+    return {
+        "warnings": warnings,
+        "dataSources": build_data_sources(
+            progress_configured=from_progress_api,
+            metadata_configured=metadata_useful,
+            progress_status=STATUS_ACTIVE if from_progress_api else None,
+            metadata_status=STATUS_ACTIVE if metadata_useful else None,
+            progress_label="Latest /progress",
+            metadata_label="Log events",
+        ),
+        "progressWarning": None,
+        "metadataWarning": None,
+        "display": display,
+        "error": None,
+        "pageTitle": _PAGE_TITLE,
+        "pageSubtitle": _page_subtitle(as_of, from_progress_api=from_progress_api),
+    }

--- a/migration/mongosync_insights/lib/logs_metrics.py
+++ b/migration/mongosync_insights/lib/logs_metrics.py
@@ -29,7 +29,7 @@ from .otel_metrics import MetricsCollector, create_metrics_plots
 from .plot_theme import apply_mi_theme, section_label_style
 from .log_store import LogStore
 from .log_store_registry import log_store_registry
-from .log_summary import build_log_summary_payload, extract_latest_progress
+from .log_summary import SummaryMigrationState, build_log_summary_payload, extract_latest_progress
 from .snapshot_store import save_snapshot
 
 _DECOMPRESS_ERRORS = (
@@ -40,6 +40,24 @@ _DECOMPRESS_ERRORS = (
     zipfile.BadZipFile,
     tarfile.TarError,
 )
+
+_LOG_LINE_PROGRESS_FORMAT = (
+    "{desc}: Total {n}, Time: {elapsed}, Lines/sec: {lines_per_sec}"
+)
+
+
+class _LogLineProgress(tqdm):
+    @property
+    def format_dict(self):
+        fmt = dict(super().format_dict)
+        rate = fmt.get("rate")
+        if rate is None:
+            elapsed = fmt.get("elapsed") or 0
+            count = fmt.get("n") or 0
+            if elapsed > 0:
+                rate = count / elapsed
+        fmt["lines_per_sec"] = f"{rate:.2f}" if rate is not None else "?"
+        return fmt
 
 
 def detect_mime_type(file_sample: bytes, filename: str) -> str:
@@ -271,6 +289,7 @@ def upload_file():
             'partition_multi_created': re.compile(r"Creating initial partitions for non-capped collection", re.IGNORECASE),
             'partition_sampling_info': re.compile(r"Pre-sampling information", re.IGNORECASE),
             'partition_persisted_after_sampling': re.compile(r"Persisted a new partition after sampling", re.IGNORECASE),
+            'index_creation_progress': re.compile(r"Index creation progress", re.IGNORECASE),
         }
         
         # Load error patterns from external file
@@ -306,6 +325,8 @@ def upload_file():
         partition_persisted_after_sampling = []
         verifier_dst_lag_items = []
         verifier_src_lag_items = []
+        index_creation_progress_json = []
+        summary_state = SummaryMigrationState()
         
         # Initialize metrics collector for prometheus metrics
         metrics_collector = MetricsCollector()
@@ -360,7 +381,13 @@ def upload_file():
                 file_iterator = file
                 use_classified = False
         
-            for item in tqdm(file_iterator, desc="Processing log file"):
+            print(f"Log file: {filename}", flush=True)
+            line_progress = _LogLineProgress(
+                file_iterator,
+                desc="Processing lines",
+                bar_format=_LOG_LINE_PROGRESS_FORMAT,
+            )
+            for item in line_progress:
                 line_count += 1
             
                 # Handle classified vs non-classified iterators
@@ -414,12 +441,34 @@ def upload_file():
                 
                     if patterns['sent_response'].search(message):
                         mongosync_sent_response.append(json_obj)
+                        try:
+                            progress_body = json.loads(json_obj.get("body") or "{}")
+                            response_progress = (progress_body or {}).get("progress")
+                            if isinstance(response_progress, dict):
+                                summary_state.note_progress(
+                                    response_progress, json_obj.get("time")
+                                )
+                        except (json.JSONDecodeError, TypeError):
+                            pass
+
+                    if patterns['index_creation_progress'].search(message):
+                        index_creation_progress_json.append(json_obj)
+                        summary_state.note_index_building(
+                            json_obj.get("indexCreationProgress"),
+                            json_obj.get("time"),
+                        )
                 
                     if patterns['phase_transitions'].search(message):
                         phase_transitions_json.append(json_obj)
+                        phase_event = _phase_event_from_info(json_obj)
+                        if phase_event:
+                            summary_state.note_phase(phase_event[1], phase_event[0])
 
                     if patterns['phase_in_memory'].search(message):
                         phase_in_memory_json.append(json_obj)
+                        phase_event = _phase_event_from_in_memory(json_obj)
+                        if phase_event:
+                            summary_state.note_phase(phase_event[1], phase_event[0])
                 
                     if patterns['mongosync_options'].search(message):
                         # Filter out time and level fields for options
@@ -445,6 +494,9 @@ def upload_file():
 
                     if patterns['state_transition'].search(message):
                         state_transition_json.append(json_obj)
+                        new_state = (json_obj.get("newState") or "").strip().upper()
+                        if new_state:
+                            summary_state.note_state(new_state, json_obj.get("time"))
                 
                     if patterns['crud_events_rate'].search(message):
                         mongosync_crud_rate.append(json_obj)
@@ -1587,7 +1639,7 @@ def upload_file():
         last_partitions_total = partitions_total[-1] if partitions_total else None
         summary_payload = build_log_summary_payload(
             progress=latest_progress,
-            progress_time=latest_progress_time,
+            progress_time=latest_progress_time or summary_state.progress_time,
             replication_lines=data,
             phase_events=merged_phase_events,
             natural_order_items=natural_order_data,
@@ -1598,6 +1650,9 @@ def upload_file():
             partitions_copied=last_partitions_copied,
             partitions_total=last_partitions_total,
             version_info_lines=version_info_list,
+            sent_responses=mongosync_sent_response,
+            index_creation_lines=index_creation_progress_json,
+            summary_state=summary_state,
         )
 
         template_data = {

--- a/migration/mongosync_insights/lib/logs_metrics.py
+++ b/migration/mongosync_insights/lib/logs_metrics.py
@@ -29,6 +29,7 @@ from .otel_metrics import MetricsCollector, create_metrics_plots
 from .plot_theme import apply_mi_theme, section_label_style
 from .log_store import LogStore
 from .log_store_registry import log_store_registry
+from .log_summary import build_log_summary_payload, extract_latest_progress
 from .snapshot_store import save_snapshot
 
 _DECOMPRESS_ERRORS = (
@@ -82,10 +83,15 @@ INFO_PHASE_TO_CANONICAL = {
 PHASES_EXCLUDED_FROM_MERGE = frozenset({"uninitialized"})
 
 
+def _normalize_phase_info_message(message):
+    """Normalize info-level phase messages for lookup (strip whitespace and trailing period)."""
+    return (message or "").strip().lower().rstrip(".")
+
+
 def _phase_event_from_info(json_obj):
     """Return (time, canonical, canonical) from an info-level phase log line, or None."""
-    message = (json_obj.get("message") or "").strip()
-    canonical = INFO_PHASE_TO_CANONICAL.get(message.lower())
+    message = _normalize_phase_info_message(json_obj.get("message"))
+    canonical = INFO_PHASE_TO_CANONICAL.get(message)
     if not canonical:
         return None
     t = (json_obj.get("time") or "")[:26]
@@ -259,6 +265,8 @@ def upload_file():
             'partition_copy_progress': re.compile(r"Completed writing \d+ / \d+ partitions to destination cluster", re.IGNORECASE),
             'natural_order_collections': re.compile(r"Selected for natural order collection reads", re.IGNORECASE),
             'received_request': re.compile(r"Received request", re.IGNORECASE),
+            'start_handler': re.compile(r"Start handler called", re.IGNORECASE),
+            'state_transition': re.compile(r"Transitioning the state", re.IGNORECASE),
             'partition_single_created': re.compile(r"Creating a single partition for whole collection", re.IGNORECASE),
             'partition_multi_created': re.compile(r"Creating initial partitions for non-capped collection", re.IGNORECASE),
             'partition_sampling_info': re.compile(r"Pre-sampling information", re.IGNORECASE),
@@ -290,6 +298,8 @@ def upload_file():
         matched_errors = []
         natural_order_collections = []
         mongosync_start_options = []
+        start_handler_parameters = []
+        state_transition_json = []
         partition_single_created = []
         partition_multi_created = []
         partition_sampling_info = []
@@ -427,6 +437,14 @@ def upload_file():
                             mongosync_start_options.append(body)
                         except (json.JSONDecodeError, TypeError):
                             pass
+
+                    if patterns['start_handler'].search(message):
+                        params = json_obj.get("parameters")
+                        if isinstance(params, dict):
+                            start_handler_parameters.append(params)
+
+                    if patterns['state_transition'].search(message):
+                        state_transition_json.append(json_obj)
                 
                     if patterns['crud_events_rate'].search(message):
                         mongosync_crud_rate.append(json_obj)
@@ -678,16 +696,12 @@ def upload_file():
                     partition_init_progress_completed.append(done)
                 logger.info(f"Built partition init progress time series with {len(init_events)} events")
 
-        mongosync_sent_response_body = None
-        for response in mongosync_sent_response:
-            try:  
-                parsed_body = json.loads(response['body'])
-                # Only use this response if it contains 'progress'
-                if 'progress' in parsed_body:
-                    mongosync_sent_response_body = parsed_body  
-            except (json.JSONDecodeError, TypeError):  
-                mongosync_sent_response_body = None  # If parse fails, use None 
-                logger.warning(f"No message 'sent response' found in the logs") 
+        latest_progress, latest_progress_time = extract_latest_progress(mongosync_sent_response)
+        mongosync_sent_response_body = (
+            {"progress": latest_progress} if latest_progress else None
+        )
+        if mongosync_sent_response and latest_progress is None:
+            logger.warning("No message 'sent response' with progress found in the logs") 
 
         # Create a string with all the version information
         if version_info_list and isinstance(version_info_list[0], dict):  
@@ -983,6 +997,7 @@ def upload_file():
         
         api_phase_transitions = []
         phase_transitions = ""
+        merged_phase_events = []
         # Check that mongosync_sent_response_body is a dict before searching for 'progress'  
         if isinstance(mongosync_sent_response_body, dict):
             if 'progress' in mongosync_sent_response_body:
@@ -1005,6 +1020,7 @@ def upload_file():
                 api_transitions=api_phase_transitions or None,
             )
             if merged:
+                merged_phase_events = merged
                 ts_t_list_formatted = [t for t, _ in merged]
                 phase_list = [label for _, label in merged]
                 phase_transitions = True
@@ -1567,6 +1583,23 @@ def upload_file():
         has_logs_data = logs_line_count > 0 and len(data) > 0
         has_metrics_data = metrics_collector.metrics_count > 0
 
+        last_partitions_copied = partitions_copied[-1] if partitions_copied else None
+        last_partitions_total = partitions_total[-1] if partitions_total else None
+        summary_payload = build_log_summary_payload(
+            progress=latest_progress,
+            progress_time=latest_progress_time,
+            replication_lines=data,
+            phase_events=merged_phase_events,
+            natural_order_items=natural_order_data,
+            start_options=mongosync_start_options,
+            hidden_flags=mongosync_hiddenflags,
+            start_handler_parameters=start_handler_parameters,
+            state_transitions=state_transition_json,
+            partitions_copied=last_partitions_copied,
+            partitions_total=last_partitions_total,
+            version_info_lines=version_info_list,
+        )
+
         template_data = {
             'plot_json': plot_json,
             'metrics_plot_json': metrics_plot_json,
@@ -1577,6 +1610,7 @@ def upload_file():
             'errors_data': matched_errors,
             'partition_init_data': partition_init_data,
             'progress_data': progress_data,
+            'summary_payload': summary_payload,
             'has_logs_data': has_logs_data,
             'has_metrics_data': has_metrics_data,
             'log_viewer_lines': log_viewer_lines_out,

--- a/migration/mongosync_insights/lib/utils.py
+++ b/migration/mongosync_insights/lib/utils.py
@@ -30,6 +30,18 @@ def format_lag_time_seconds(seconds):
     return f"{days}d {hours}h"
 
 
+def format_seconds_title(seconds):
+    """Hover text for duration fields (e.g. '1,582 seconds')."""
+    if seconds is None or seconds < 0:
+        return None
+    try:
+        total = int(seconds)
+    except (TypeError, ValueError):
+        return None
+    unit = "second" if total == 1 else "seconds"
+    return f"{total:,} {unit}"
+
+
 def format_count(value):
     if value is None:
         return "—"

--- a/migration/mongosync_insights/static/css/mi-live-monitor.css
+++ b/migration/mongosync_insights/static/css/mi-live-monitor.css
@@ -212,6 +212,23 @@
     line-height: 1;
 }
 
+.lm-phase-times-timezone-below {
+    margin-top: 8px;
+    margin-left: calc(1em + 4px);
+    font-size: 12px;
+}
+
+.lm-phase-times-timezone {
+    color: var(--lm-text-secondary);
+    font-size: 12px;
+    font-weight: 400;
+}
+
+.lm-phase-times-note {
+    margin-top: 8px;
+    font-size: 12px;
+}
+
 .lm-phase-times-details {
     display: none;
     margin-top: 10px;
@@ -249,11 +266,6 @@
 .lm-phase-times-table td:last-child {
     font-variant-numeric: tabular-nums;
     white-space: nowrap;
-}
-
-.lm-phase-times-note {
-    margin-top: 8px;
-    font-size: 12px;
 }
 
 .lm-natural-order-block {

--- a/migration/mongosync_insights/static/css/mi-live-monitor.css
+++ b/migration/mongosync_insights/static/css/mi-live-monitor.css
@@ -167,6 +167,20 @@
     margin-top: 4px;
 }
 
+.lm-sync-subsection {
+    margin-top: 16px;
+    padding-top: 16px;
+    border-top: 1px solid var(--lm-card-border);
+}
+
+.lm-sync-subsection .lm-copied-line {
+    margin-top: 0;
+}
+
+.lm-sync-subsection .lm-copied-block {
+    margin-top: 0;
+}
+
 .lm-phase-times-block {
     margin-top: 16px;
     padding-top: 16px;
@@ -537,6 +551,52 @@
     font-size: 15px;
 }
 
+.lm-metric .lm-mvalue.lm-lag-high {
+    font-weight: 700;
+    color: var(--mongodb-red-base);
+}
+
+.lm-has-hover {
+    position: relative;
+}
+
+.lm-has-hover:not(button) {
+    cursor: help;
+}
+
+.lm-has-hover::after {
+    content: attr(data-hover-title);
+    position: absolute;
+    left: 0;
+    bottom: calc(100% + 6px);
+    z-index: 6;
+    padding: 6px 8px;
+    background: var(--lm-card-bg);
+    color: var(--lm-text-primary);
+    border: 1px solid var(--lm-card-border);
+    border-radius: var(--mi-radius-sm);
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 1.3;
+    text-transform: none;
+    letter-spacing: 0;
+    white-space: nowrap;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+}
+
+.lm-has-hover-multiline::after {
+    white-space: pre-line;
+    max-width: 280px;
+}
+
+.lm-has-hover:hover::after,
+.lm-has-hover:focus-visible::after {
+    opacity: 1;
+    visibility: visible;
+}
+
 .lm-direction {
     display: flex;
     align-items: center;
@@ -655,6 +715,10 @@
     color: var(--mongodb-red-light1);
 }
 
+[data-theme="dark"] .lm-metric .lm-mvalue.lm-lag-high {
+    color: var(--mongodb-red-light1);
+}
+
 [data-theme="dark"] .lm-banner.info {
     background: rgba(1, 107, 248, 0.15);
     border-color: var(--mongodb-blue-base);
@@ -693,6 +757,24 @@
     font-size: 18px;
     font-weight: 600;
     margin: 0 0 4px;
+    color: var(--lm-text-primary);
+}
+
+.lm-migration-progress-title {
+    justify-content: space-between;
+    gap: 16px;
+}
+
+.lm-mongosync-version {
+    margin-left: auto;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--lm-text-secondary);
+    white-space: nowrap;
+}
+
+.lm-mongosync-version-value {
+    font-weight: 600;
     color: var(--lm-text-primary);
 }
 

--- a/migration/mongosync_insights/static/css/mi-upload-results.css
+++ b/migration/mongosync_insights/static/css/mi-upload-results.css
@@ -23,6 +23,11 @@
     min-height: 400px;
 }
 
+.ur-main .lm-main {
+    max-width: 1080px;
+    padding: 24px 8px 32px;
+}
+
 .ur-main .tabs-container {
     max-width: 1550px;
     margin: 0 auto;
@@ -30,6 +35,7 @@
 
 .ur-main .tab-buttons {
     display: flex;
+    flex-wrap: wrap;
     gap: 4px;
     margin-bottom: 0;
     border-bottom: 2px solid var(--mongodb-green-dark2);

--- a/migration/mongosync_insights/static/js/mi-live-monitor.js
+++ b/migration/mongosync_insights/static/js/mi-live-monitor.js
@@ -42,10 +42,20 @@
         return wrap;
     }
 
+    function applyHoverTitle(node, title) {
+        if (!node || !title) return node;
+        node.classList.add('lm-has-hover');
+        if (title.indexOf('\n') !== -1) {
+            node.classList.add('lm-has-hover-multiline');
+        }
+        node.setAttribute('data-hover-title', title);
+        return node;
+    }
+
     function metricTile(item) {
         var box = el('div', 'lm-metric');
         box.appendChild(el('div', 'lm-mlabel', item.label));
-        var valueClass = 'lm-mvalue' + (item.small ? ' small' : '');
+        var valueClass = 'lm-mvalue' + (item.small ? ' small' : '') + (item.highLag ? ' lm-lag-high' : '');
         if (item.badge) {
             var val = el('div', valueClass);
             val.appendChild(badge(item.value, item.badge, false));
@@ -53,6 +63,7 @@
         } else {
             box.appendChild(el('div', valueClass, String(item.value)));
         }
+        applyHoverTitle(box, item.title);
         return box;
     }
 
@@ -68,10 +79,40 @@
         return section;
     }
 
-    function kvRow(label, value) {
+    function cardWithTitleElement(titleEl, desc, bodyChildren, bodyClassName) {
+        var section = el('section', 'lm-card');
+        if (titleEl) section.appendChild(titleEl);
+        if (desc) section.appendChild(el('p', 'lm-card-desc', desc));
+        var body = el('div', 'lm-card-body' + (bodyClassName ? ' ' + bodyClassName : ''));
+        (bodyChildren || []).forEach(function (c) {
+            if (c) body.appendChild(c);
+        });
+        section.appendChild(body);
+        return section;
+    }
+
+    function migrationProgressTitle(sync) {
+        var title = el('h2', 'lm-card-title-row lm-migration-progress-title');
+        title.appendChild(document.createTextNode('Migration Progress'));
+        if (sync.showMongosyncVersion) {
+            var versionWrap = el('span', 'lm-mongosync-version');
+            versionWrap.appendChild(document.createTextNode('Mongosync Version: '));
+            var versionValue = sync.mongosyncVersion || '—';
+            versionWrap.appendChild(el('span', 'lm-mongosync-version-value', versionValue));
+            if (!sync.mongosyncVersion && sync.mongosyncVersionMissingTitle) {
+                applyHoverTitle(versionWrap, sync.mongosyncVersionMissingTitle);
+            }
+            title.appendChild(versionWrap);
+        }
+        return title;
+    }
+
+    function kvRow(label, value, title) {
         var rowEl = el('div', 'lm-kv');
         rowEl.appendChild(el('span', 'lm-k', label));
-        rowEl.appendChild(el('span', 'lm-v', value));
+        var valueEl = el('span', 'lm-v', value);
+        applyHoverTitle(valueEl, title);
+        rowEl.appendChild(valueEl);
         return rowEl;
     }
 
@@ -285,28 +326,60 @@
         return block;
     }
 
+    function copyPercentLabel(sync) {
+        if (!sync.showCopyProgress || sync.copyPercent == null) {
+            return null;
+        }
+        return el('span', 'lm-muted', sync.copyPercent.toFixed(1) + '%');
+    }
+
     function copiedProgressBlock(sync) {
-        var hasDetails = !!(sync.collectionsCopiedLabel || sync.partitionsCopiedLabel);
+        var hasDetails = !!(
+            sync.collectionsCopiedLabel ||
+            sync.partitionsCopiedLabel ||
+            sync.collectionsFinishedLabel
+        );
         if (!sync.copiedLabel && !hasDetails) {
             return null;
         }
 
-        if (!sync.copiedLabel) {
-            var fallback = el('div', 'lm-copied-block');
+        function appendCopyDetailLines(parent, useDetailClass) {
+            var lineClass = useDetailClass ? 'lm-muted lm-copied-detail-line' : 'lm-muted lm-copied-line';
             if (sync.collectionsCopiedLabel) {
-                fallback.appendChild(el('div', 'lm-muted lm-copied-line', sync.collectionsCopiedLabel));
+                parent.appendChild(el('div', lineClass, sync.collectionsCopiedLabel));
             }
             if (sync.partitionsCopiedLabel) {
-                fallback.appendChild(el('div', 'lm-muted lm-copied-line', sync.partitionsCopiedLabel));
+                parent.appendChild(el('div', lineClass, sync.partitionsCopiedLabel));
             }
+            if (sync.collectionsFinishedLabel) {
+                parent.appendChild(el('div', lineClass, sync.collectionsFinishedLabel));
+            }
+        }
+
+        if (!sync.copiedLabel) {
+            var fallback = el('div', 'lm-copied-block');
+            appendCopyDetailLines(fallback, false);
             return fallback;
         }
 
         if (!hasDetails) {
-            return el('div', 'lm-muted lm-copied-line', sync.copiedLabel);
+            var simpleBlock = el('div', 'lm-copied-block');
+            var simpleRow = el('div', 'lm-phase-row');
+            var line = el('div', 'lm-muted lm-copied-line');
+            line.style.marginTop = '0';
+            line.appendChild(document.createTextNode(sync.copiedLabel));
+            applyHoverTitle(line, sync.copiedTitle);
+            simpleRow.appendChild(line);
+            var simplePercent = copyPercentLabel(sync);
+            if (simplePercent) {
+                simpleRow.appendChild(simplePercent);
+            }
+            simpleBlock.appendChild(simpleRow);
+            return simpleBlock;
         }
 
         var block = el('div', 'lm-copied-block');
+        var copiedRow = el('div', 'lm-phase-row');
         var toggle = el('button', 'lm-copied-toggle lm-muted');
         toggle.type = 'button';
         toggle.setAttribute('aria-expanded', copyDetailsExpanded ? 'true' : 'false');
@@ -314,18 +387,16 @@
         var chevron = el('span', 'lm-copied-chevron', copyDetailsExpanded ? '▾' : '▸');
         toggle.appendChild(chevron);
         toggle.appendChild(document.createTextNode(sync.copiedLabel));
+        applyHoverTitle(toggle, sync.copiedTitle);
+        copiedRow.appendChild(toggle);
+        var copiedPercent = copyPercentLabel(sync);
+        if (copiedPercent) {
+            copiedRow.appendChild(copiedPercent);
+        }
+        block.appendChild(copiedRow);
 
         var details = el('div', 'lm-copied-details' + (copyDetailsExpanded ? ' is-open' : ''));
-        if (sync.collectionsCopiedLabel) {
-            details.appendChild(
-                el('div', 'lm-muted lm-copied-detail-line', sync.collectionsCopiedLabel)
-            );
-        }
-        if (sync.partitionsCopiedLabel) {
-            details.appendChild(
-                el('div', 'lm-muted lm-copied-detail-line', sync.partitionsCopiedLabel)
-            );
-        }
+        appendCopyDetailLines(details, true);
 
         toggle.addEventListener('click', function () {
             copyDetailsExpanded = !copyDetailsExpanded;
@@ -334,7 +405,6 @@
             details.classList.toggle('is-open', copyDetailsExpanded);
         });
 
-        block.appendChild(toggle);
         block.appendChild(details);
         return block;
     }
@@ -343,20 +413,19 @@
         if (!sync) return null;
         var phaseRow = el('div', 'lm-phase-row');
         var phaseText = el('span');
-        phaseText.appendChild(document.createTextNode('Phase: '));
+        phaseText.appendChild(document.createTextNode('Current Phase: '));
         phaseText.appendChild(el('b', null, sync.phase));
         phaseRow.appendChild(phaseText);
-        if (sync.showCopyProgress && sync.copyPercent != null) {
-            phaseRow.appendChild(el('span', 'lm-muted', sync.copyPercent.toFixed(1) + '%'));
-        }
 
         var children = [phaseRow];
-        if (sync.showCopyProgress) {
-            children.push(progressBar(sync.copyPercent, sync.copyIndeterminate));
-        }
         var copiedBlock = copiedProgressBlock(sync);
         if (copiedBlock) {
-            children.push(copiedBlock);
+            var copiedSection = el('div', 'lm-sync-subsection');
+            copiedSection.appendChild(copiedBlock);
+            children.push(copiedSection);
+        }
+        if (sync.showCopyProgress) {
+            children.push(progressBar(sync.copyPercent, sync.copyIndeterminate));
         }
 
         var metrics = el('div', 'lm-metrics');
@@ -378,7 +447,7 @@
             children.push(phaseTimesBlock);
         }
 
-        return card('Migration Progress', null, children);
+        return cardWithTitleElement(migrationProgressTitle(sync), null, children);
     }
 
     function renderIndexBuilding(idx) {
@@ -432,7 +501,7 @@
             var colEl = el('div', 'lm-ver-col');
             colEl.appendChild(el('div', 'lm-section-label', col.label));
             (col.rows || []).forEach(function (r) {
-                colEl.appendChild(kvRow(r.label, r.value));
+                colEl.appendChild(kvRow(r.label, r.value, r.title));
             });
             row.appendChild(colEl);
         });
@@ -455,12 +524,13 @@
         });
     }
 
-    function renderToolbar(display, dataSources) {
+    function renderToolbar(display, dataSources, options) {
+        options = options || {};
         var toolbar = el('div', 'lm-toolbar');
         var textBlock = el('div', 'lm-toolbar-text');
 
         var title = el('h1', 'lm-page-title');
-        title.appendChild(document.createTextNode('Migration Monitoring'));
+        title.appendChild(document.createTextNode(options.pageTitle || 'Migration Monitoring'));
         if (display && display.stateBadge) {
             title.appendChild(
                 badge(display.stateBadge.label, display.stateBadge.color, true)
@@ -473,6 +543,9 @@
         }
         appendDataSourceBadges(title, dataSources);
         textBlock.appendChild(title);
+        if (options.pageSubtitle) {
+            textBlock.appendChild(el('p', 'lm-page-subtitle', options.pageSubtitle));
+        }
 
         toolbar.appendChild(textBlock);
         return toolbar;
@@ -481,10 +554,15 @@
     function renderProgressMonitor(root, payload) {
         if (!root) return;
         root.replaceChildren();
+        payload = payload || {};
+        var toolbarOpts = {
+            pageTitle: payload.pageTitle,
+            pageSubtitle: payload.pageSubtitle,
+        };
 
         if (payload.error && !payload.display) {
             var errShell = el('div', 'lm-stack');
-            errShell.appendChild(renderToolbar(null, payload.dataSources));
+            errShell.appendChild(renderToolbar(null, payload.dataSources, toolbarOpts));
             errShell.appendChild(banner('danger', payload.error));
             root.appendChild(errShell);
             return;
@@ -492,7 +570,7 @@
 
         if (!payload.display) {
             var infoShell = el('div', 'lm-stack');
-            infoShell.appendChild(renderToolbar(null, payload.dataSources));
+            infoShell.appendChild(renderToolbar(null, payload.dataSources, toolbarOpts));
             infoShell.appendChild(
                 banner(
                     'info',
@@ -506,7 +584,7 @@
 
         var display = payload.display;
 
-        root.appendChild(renderToolbar(display, payload.dataSources));
+        root.appendChild(renderToolbar(display, payload.dataSources, toolbarOpts));
 
         var stack = el('div', 'lm-stack lm-stack-after-toolbar');
         if (payload.progressWarning) {

--- a/migration/mongosync_insights/static/js/mi-live-monitor.js
+++ b/migration/mongosync_insights/static/js/mi-live-monitor.js
@@ -307,8 +307,7 @@
         });
         table.appendChild(tbody);
         details.appendChild(table);
-
-        if (data.timezoneNote) {
+        if (data.timezoneNote && !data.timezoneNoteBelowTitle) {
             details.appendChild(
                 el('div', 'lm-muted lm-phase-times-note', 'Times in ' + data.timezoneNote)
             );
@@ -322,6 +321,15 @@
         });
 
         block.appendChild(toggle);
+        if (data.timezoneNote && data.timezoneNoteBelowTitle) {
+            block.appendChild(
+                el(
+                    'div',
+                    'lm-muted lm-phase-times-timezone lm-phase-times-timezone-below',
+                    'Times in ' + data.timezoneNote
+                )
+            );
+        }
         block.appendChild(details);
         return block;
     }
@@ -336,8 +344,7 @@
     function copiedProgressBlock(sync) {
         var hasDetails = !!(
             sync.collectionsCopiedLabel ||
-            sync.partitionsCopiedLabel ||
-            sync.collectionsFinishedLabel
+            sync.partitionsCopiedLabel
         );
         if (!sync.copiedLabel && !hasDetails) {
             return null;
@@ -350,9 +357,6 @@
             }
             if (sync.partitionsCopiedLabel) {
                 parent.appendChild(el('div', lineClass, sync.partitionsCopiedLabel));
-            }
-            if (sync.collectionsFinishedLabel) {
-                parent.appendChild(el('div', lineClass, sync.collectionsFinishedLabel));
             }
         }
 

--- a/migration/mongosync_insights/static/js/mi-verifier-monitor.js
+++ b/migration/mongosync_insights/static/js/mi-verifier-monitor.js
@@ -42,10 +42,20 @@
         return wrap;
     }
 
+    function applyHoverTitle(node, title) {
+        if (!node || !title) return node;
+        node.classList.add('lm-has-hover');
+        if (title.indexOf('\n') !== -1) {
+            node.classList.add('lm-has-hover-multiline');
+        }
+        node.setAttribute('data-hover-title', title);
+        return node;
+    }
+
     function metricTile(item) {
         var box = el('div', 'lm-metric');
         box.appendChild(el('div', 'lm-mlabel', item.label));
-        var valueClass = 'lm-mvalue' + (item.small ? ' small' : '');
+        var valueClass = 'lm-mvalue' + (item.small ? ' small' : '') + (item.highLag ? ' lm-lag-high' : '');
         if (item.badge) {
             var val = el('div', valueClass);
             val.appendChild(badge(item.value, item.badge, false));
@@ -53,6 +63,7 @@
         } else {
             box.appendChild(el('div', valueClass, String(item.value)));
         }
+        applyHoverTitle(box, item.title);
         return box;
     }
 
@@ -80,10 +91,12 @@
         return section;
     }
 
-    function kvRow(label, value) {
+    function kvRow(label, value, title) {
         var rowEl = el('div', 'lm-kv');
         rowEl.appendChild(el('span', 'lm-k', label));
-        rowEl.appendChild(el('span', 'lm-v', value));
+        var valueEl = el('span', 'lm-v', value);
+        applyHoverTitle(valueEl, title);
+        rowEl.appendChild(valueEl);
         return rowEl;
     }
 
@@ -166,6 +179,14 @@
         }
     }
 
+    function formatSecondsTitle(seconds) {
+        if (seconds == null || seconds === '') return null;
+        var n = Number(seconds);
+        if (!isFinite(n) || n < 0) return null;
+        var total = Math.floor(n);
+        return total.toLocaleString('en-US') + (total === 1 ? ' second' : ' seconds');
+    }
+
     function formatLagSecs(seconds) {
         if (seconds == null || seconds === '') return '—';
         var n = Number(seconds);
@@ -193,7 +214,7 @@
 
         var metrics = el('div', 'lm-metrics lm-verifier-metrics');
         [
-            { label: 'Lag', value: formatLagSecs(changeStats.lagSecs) },
+            { label: 'Lag', value: formatLagSecs(changeStats.lagSecs), title: formatSecondsTitle(changeStats.lagSecs) },
             { label: 'Events/sec', value: formatRate(changeStats.eventsPerSecond) },
             {
                 label: 'Buffer saturation',
@@ -275,7 +296,10 @@
         if (progress.estCheckSecsRemaining != null) {
             var etaText = formatCheckEta(progress.estCheckSecsRemaining);
             if (etaText) {
-                body.appendChild(kvRow('Initial check ETA', etaText));
+                var etaTitle = etaText === 'Complete'
+                    ? null
+                    : formatSecondsTitle(progress.estCheckSecsRemaining);
+                body.appendChild(kvRow('Initial check ETA', etaText, etaTitle));
             }
         }
 

--- a/migration/mongosync_insights/templates/upload_results.html
+++ b/migration/mongosync_insights/templates/upload_results.html
@@ -9,6 +9,7 @@
 {% block head_links %}
     <link rel="preload" href="https://assets.mongodb-cdn.com/mms/static/font/EuclidCircularA-Regular-WebXL.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="https://assets.mongodb-cdn.com/mms/static/font/EuclidCircularA-Semibold-WebXL.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="stylesheet" href="/static/css/mi-live-monitor.css">
     <link rel="stylesheet" href="/static/css/mi-upload-results.css">
 {% endblock %}
 
@@ -16,8 +17,11 @@
 <div class="ur-main">
 <div class="tabs-container">
     <div class="tab-buttons">
+        {% if has_logs_data %}
+        <button class="tab-btn active" onclick="switchTab('summary')" id="tab-summary">Summary</button>
+        {% endif %}
         {% if has_logs_data or (not has_metrics_data) %}
-        <button class="tab-btn {% if has_logs_data or (not has_metrics_data) %}active{% endif %}" onclick="switchTab('charts')" id="tab-charts">Mongosync Logs</button>
+        <button class="tab-btn {% if not has_logs_data %}active{% endif %}" onclick="switchTab('charts')" id="tab-charts">Mongosync Logs</button>
         {% endif %}
         {% if has_metrics_data %}
         <button class="tab-btn {% if has_metrics_data and not has_logs_data %}active{% endif %}" onclick="switchTab('metrics')" id="tab-metrics">Mongosync Metrics</button>
@@ -30,8 +34,14 @@
         {% endif %}
     </div>
 
+    {% if has_logs_data %}
+    <div id="summary-tab" class="tab-content active">
+        <div id="log-summary-root" class="lm-main"></div>
+    </div>
+    {% endif %}
+
     {% if has_logs_data or (not has_metrics_data) %}
-    <div id="charts-tab" class="tab-content {% if has_logs_data or (not has_metrics_data) %}active{% endif %}">
+    <div id="charts-tab" class="tab-content {% if not has_logs_data %}active{% endif %}">
         <div class="plot-container">
             <div id="plot"></div>
         </div>
@@ -399,6 +409,7 @@
 {% endblock %}
 
 {% block scripts %}
+<script src="/static/js/mi-live-monitor.js"></script>
 <script>
 // ===== Chart Info Badge Overlay =====
 
@@ -643,6 +654,7 @@ var naturalOrderData = {{ natural_order_data | tojson }};
 var errorsData = {{ errors_data | tojson }};
 var partitionInitData = {{ partition_init_data | tojson }};
 var progressData = {{ progress_data | default([]) | tojson }};
+var summaryPayload = {{ summary_payload | default({}) | tojson }};
 
 function switchTab(tabName) {
     document.querySelectorAll('.tab-btn').forEach(btn => btn.classList.remove('active'));
@@ -1621,6 +1633,18 @@ function lvBackToTail() {
 // --- Init ---
 document.addEventListener('DOMContentLoaded', function() {
     lvUpdateControlsState();
+    var summaryRoot = document.getElementById('log-summary-root');
+    if (summaryRoot && typeof miRenderProgressMonitor === 'function') {
+        var payload = summaryPayload;
+        if (!payload || (!payload.display && !payload.error)) {
+            payload = {
+                error: 'No summary is available for this saved analysis. Re-upload the log to generate the Summary tab.',
+                pageTitle: 'Summary',
+                pageSubtitle: 'Snapshot from this log (not live)'
+            };
+        }
+        miRenderProgressMonitor(summaryRoot, payload);
+    }
 });
 </script>
 {% endblock %}

--- a/migration/mongosync_insights/tests/TESTING.md
+++ b/migration/mongosync_insights/tests/TESTING.md
@@ -3,7 +3,7 @@
 **Scope:** `migration/mongosync_insights/tests/`  
 **Framework:** pytest (with some `unittest.TestCase` classes)  
 **CI:** [`.github/workflows/mongosync-insights-tests.yml`](../../../.github/workflows/mongosync-insights-tests.yml) — runs `python -m pytest tests/ -q` on Python 3.11  
-**Total:** **516 tests** across **30 test files** (+ `conftest.py` shared fixtures)
+**Total:** **543 tests** across **31 test files** (+ `conftest.py` shared fixtures)
 
 ---
 
@@ -13,12 +13,12 @@
 |------|------:|------:|-------------------|
 | App config & bootstrap | 4 | 88 | Env parsing, endpoint URLs, file classification, sessions, app factory |
 | Security & paths | 2 | 22 | Connection string sanitization, store ID validation, path traversal |
-| Log storage & routes | 7 | 69 | Upload, search, decompress, snapshots, FTS, timestamps |
+| Log storage & routes | 8 | 87 | Upload, search, decompress, snapshots, FTS, timestamps, Summary tab payload |
 | Metrics & OTEL parsing | 2 | 39 | MIME detection, phase events, Prometheus/OTEL log parsing |
-| Live monitoring | 6 | 109 | Progress/verifier API clients, routes, metadata, formatting, charts |
+| Live monitoring | 6 | 118 | Progress/verifier API clients, routes, metadata, formatting, charts |
 | Migration metadata UI | 8 | 114 | Verification mode, index building, filters, natural order, phases |
 | Migration verifier | 1 | 75 | MongoDB verifier queries, badges, payloads, generation history |
-| **Total** | **30** | **516** | |
+| **Total** | **31** | **543** | |
 
 ---
 
@@ -27,7 +27,7 @@
 ```bash
 cd migration/mongosync_insights
 pip install -r requirements.txt -r requirements-dev.txt
-python -m pytest tests/ -q          # all 516 tests
+python -m pytest tests/ -q          # all 543 tests
 python -m pytest tests/ --collect-only -q   # list without running (verify current count)
 python -m pytest tests/test_log_time.py -v  # single file
 ```
@@ -52,13 +52,14 @@ python -m pytest tests/test_log_time.py -v  # single file
 | `test_connection_validator.py` | 5 | Strips credentials from URIs, HTML-escapes hosts, fallback for malformed URIs |
 | `test_store_paths.py` | 17 | UUID store IDs, path traversal rejection, poisoned snapshot JSON, registry path constraints |
 
-### 3. Log storage & routes (69 tests)
+### 3. Log storage & routes (87 tests)
 
 | File | Tests | Validates |
 |------|------:|-----------|
 | `test_log_store.py` | 14 | Insert, FTS search, pagination, timestamp range queries (with/without Z), delete |
 | `test_log_store_registry.py` | 4 | Store open/cache hit-miss, expiry, maintenance cleanup |
 | `test_log_time.py` | 7 | Log search datetime parsing, start/end bound normalization |
+| `test_log_summary.py` | 18 | Latest `/progress` extraction, log-derived metadata, Summary tab payload |
 | `test_file_decompressor.py` | 20 | gzip/bzip2/tar/zip decompression, macOS metadata skipping, MIME routing |
 | `test_logs_routes.py` | 17 | `/logs` home, upload, search (text + timestamp, no-Z stored logs), snapshot list/load/delete |
 | `test_upload_fixtures.py` | 3 | End-to-end upload + search with sample fixtures |
@@ -71,15 +72,15 @@ python -m pytest tests/test_log_time.py -v  # single file
 | `test_logs_metrics.py` | 21 | MIME sniffing, phase event extraction from logs/API, merge logic, commit/write flags |
 | `test_otel_metrics.py` | 18 | Prometheus label/message parsing, metrics log lines, collector histograms, config/titles |
 
-### 5. Live monitoring (109 tests)
+### 5. Live monitoring (118 tests)
 
 | File | Tests | Validates |
 |------|------:|-----------|
-| `test_live_monitoring.py` | 21 | `fetch_progress` / `fetch_summary` / verifier progress (timeouts, HTTP errors), state badges, display builders |
+| `test_live_monitoring.py` | 23 | `fetch_progress` / `fetch_summary` / verifier progress (timeouts, HTTP errors), state badges, display builders, duration hover titles |
 | `test_live_routes.py` | 19 | `/live` home, monitoring POST, progress monitor, verifier POST/GET routes |
 | `test_live_metadata_status.py` | 24 | Lag time, write-blocking mode, sync phase normalization, progress gating (index/verification), partition byte totals |
 | `test_data_sources.py` | 6 | Data source card when endpoint/metadata configured or unavailable |
-| `test_utils.py` | 33 | Byte/count/lag/ratio formatting helpers |
+| `test_utils.py` | 40 | Byte/count/lag/ratio formatting helpers, seconds hover titles |
 | `test_plot_theme.py` | 6 | Light/dark theme tokens, annotation styles, Plotly template registration |
 
 ### 6. Migration metadata UI (114 tests)
@@ -118,7 +119,7 @@ Fixtures under `tests/fixtures/`:
 
 ---
 
-## Full Test Inventory (516 tests)
+## Full Test Inventory (543 tests)
 
 ### `test_app_config.py` (80)
 
@@ -183,9 +184,9 @@ Fixtures under `tests/fixtures/`:
 
 - Lag time, write-blocking mode (4 parametrized), sync phases (5 parametrized), progress gating (8 parametrized), verification mode keys, partition byte totals
 
-### `test_live_monitoring.py` (21)
+### `test_live_monitoring.py` (23)
 
-- Fetch progress/summary/verifier (success + error paths), state badges, display builders, no-config response shape
+- Fetch progress/summary/verifier (success + error paths), state badges, display builders, no-config response shape, duration hover titles
 
 ### `test_live_routes.py` (19)
 
@@ -202,6 +203,10 @@ Fixtures under `tests/fixtures/`:
 ### `test_log_time.py` (7)
 
 - Parse datetime, Z suffix, reject empty, normalize start/end bounds
+
+### `test_log_summary.py` (18)
+
+- Latest `/progress` from sent responses, skip invalid JSON, timestamp formatting, phase/natural-order rows, replication fallback, start-option metadata, Summary payload shape
 
 ### `test_logs_metrics.py` (21)
 
@@ -247,9 +252,9 @@ Fixtures under `tests/fixtures/`:
 
 - Upload sample log, upload metrics fixture, search after upload
 
-### `test_utils.py` (33)
+### `test_utils.py` (40)
 
-- `format_bytes_compact` (9), `format_lag_time_seconds` (7), `format_count` (5), `format_ratio` (2), `format_byte_size` (5), `convert_bytes` (5) — all parametrized
+- `format_bytes_compact` (9), `format_lag_time_seconds` (7), `format_seconds_title` (7), `format_count` (5), `format_ratio` (2), `format_byte_size` (5), `convert_bytes` (5) — all parametrized
 
 ### `test_verification_mode.py` (32)
 

--- a/migration/mongosync_insights/tests/conftest.py
+++ b/migration/mongosync_insights/tests/conftest.py
@@ -71,6 +71,7 @@ def minimal_template_data():
         "errors_data": [],
         "partition_init_data": [],
         "progress_data": [],
+        "summary_payload": {},
         "has_logs_data": False,
         "has_metrics_data": False,
         "log_viewer_lines": [],

--- a/migration/mongosync_insights/tests/test_filtered_migration.py
+++ b/migration/mongosync_insights/tests/test_filtered_migration.py
@@ -12,11 +12,11 @@ from lib.live_monitoring import _build_display, _build_filtered_migration
 class TestFormatNamespaceFilterRows(unittest.TestCase):
     def test_empty_inclusion_defaults(self):
         rows = format_namespace_filter_rows(None, "inclusion")
-        self.assertEqual(rows, [{"key": "Database", "value": "All (no filter)"}])
+        self.assertEqual(rows, [{"key": "Database", "value": "All (no filter specified)"}])
 
     def test_empty_exclusion_defaults(self):
         rows = format_namespace_filter_rows(None, "exclusion")
-        self.assertEqual(rows, [{"key": "Filter", "value": "No filter"}])
+        self.assertEqual(rows, [{"key": "Filter", "value": "None (No filter specified)"}])
 
     def test_inclusion_with_database_and_collections(self):
         rows = format_namespace_filter_rows(
@@ -26,6 +26,15 @@ class TestFormatNamespaceFilterRows(unittest.TestCase):
         by_key = {r["key"]: r["value"] for r in rows}
         self.assertEqual(by_key["Database"], "mydb")
         self.assertEqual(by_key["Collections"], "c1, c2")
+
+    def test_inclusion_with_database_only(self):
+        rows = format_namespace_filter_rows(
+            [{"database": ["mydb"], "collections": None}],
+            "inclusion",
+        )
+        by_key = {r["key"]: r["value"] for r in rows}
+        self.assertEqual(by_key["Database"], "mydb")
+        self.assertEqual(by_key["Collections"], "All (no filter specified)")
 
     def test_exclusion_with_entries(self):
         rows = format_namespace_filter_rows(
@@ -64,7 +73,7 @@ class TestFilteredMigrationDisplay(unittest.TestCase):
         metadata = {
             "namespaceFilterActive": True,
             "inclusionFilterRows": [{"key": "Database", "value": "mydb"}],
-            "exclusionFilterRows": [{"key": "Filter", "value": "No filter"}],
+            "exclusionFilterRows": [{"key": "Filter", "value": "None (No filter specified)"}],
         }
         card = _build_filtered_migration(metadata)
         self.assertEqual(card["title"], "Filtered migration")
@@ -81,7 +90,7 @@ class TestFilteredMigrationDisplay(unittest.TestCase):
             "phase": "Collection copy",
             "namespaceFilterActive": True,
             "inclusionFilterRows": [{"key": "Database", "value": "mydb"}],
-            "exclusionFilterRows": [{"key": "Filter", "value": "No filter"}],
+            "exclusionFilterRows": [{"key": "Filter", "value": "None (No filter specified)"}],
         }
         display = _build_display(None, metadata, progress_available=False)
         self.assertIsNotNone(display["filteredMigration"])
@@ -95,8 +104,8 @@ class TestFilteredMigrationDisplay(unittest.TestCase):
         metadata = {
             "state": "RUNNING",
             "namespaceFilterActive": False,
-            "inclusionFilterRows": [{"key": "Database", "value": "All (no filter)"}],
-            "exclusionFilterRows": [{"key": "Filter", "value": "No filter"}],
+            "inclusionFilterRows": [{"key": "Database", "value": "All (no filter specified)"}],
+            "exclusionFilterRows": [{"key": "Filter", "value": "None (No filter specified)"}],
         }
         display = _build_display(None, metadata, progress_available=False)
         self.assertIsNone(display["filteredMigration"])

--- a/migration/mongosync_insights/tests/test_live_monitoring.py
+++ b/migration/mongosync_insights/tests/test_live_monitoring.py
@@ -11,11 +11,16 @@ from lib.app_config import (
 )
 from lib.live_monitoring import (
     ProgressFetchError,
+    _build_collections_finished_label,
+    _build_db_only_metrics,
     _build_direction,
+    _build_index_building_card,
     _build_metadata_metrics,
     _build_progress_metrics,
+    _build_sync_card,
     _derive_state_badge,
     _state_badge_color,
+    _verification_side_kv,
     build_live_monitor_payload,
     fetch_progress,
     fetch_summary,
@@ -193,17 +198,69 @@ class TestBuildHelpers:
 
         assert progress_monitor_no_config_response()["dataSources"] is None
 
-    def test_build_metadata_metrics(self):
+    def test_build_metadata_metrics_live_labels(self):
         metrics = _build_metadata_metrics({"start": "2026-01-01", "buildIndexes": "After Data Copy"})
         labels = [m["label"] for m in metrics]
-        assert "Start" in labels
+        assert "Migration Start time" in labels
+        assert "Finish" in labels
+        assert "Migration Committed" not in labels
         assert "Build Indexes" in labels
+        start_metric = next(m for m in metrics if m["label"] == "Migration Start time")
+        assert "initializing collections and indexes" in start_metric["title"]
+        assert "/start" in start_metric["title"]
+
+    def test_build_metadata_metrics_summary_labels(self):
+        metrics = _build_metadata_metrics(
+            {"start": "2026-01-01", "finish": "2026-01-02"},
+            summary=True,
+        )
+        labels = [m["label"] for m in metrics]
+        assert "Migration Committed" in labels
+        assert "Finish" not in labels
 
     def test_build_progress_metrics(self):
-        metrics = _build_progress_metrics({"canCommit": True, "canWrite": False, "totalEventsApplied": 10}, 30)
+        metrics = _build_progress_metrics(
+            {
+                "canCommit": True,
+                "canWrite": False,
+                "totalEventsApplied": 10,
+                "estimatedSecondsToCEACatchup": 90,
+            },
+            1582,
+        )
         by_label = {m["label"]: m for m in metrics}
         assert by_label["Can commit"]["value"] == "TRUE"
         assert by_label["Events applied"]["value"] == "10"
+        assert by_label["Lag time"]["value"] == "26m 22s"
+        assert by_label["Lag time"]["title"] == "1,582 seconds"
+        assert by_label["Lag time"]["highLag"] is True
+        assert by_label["Catch-up estimate"]["value"] == "1m 30s"
+        assert by_label["Catch-up estimate"]["title"] == "90 seconds"
+        assert "title" not in by_label["Events applied"]
+
+    def test_db_only_metrics_lag_title(self):
+        metrics = _build_db_only_metrics(90)
+        by_label = {m["label"]: m for m in metrics}
+        assert by_label["Lag time"]["value"] == "1m 30s"
+        assert by_label["Lag time"]["title"] == "90 seconds"
+        assert by_label["Lag time"]["highLag"] is True
+        assert "title" not in by_label["Catch-up estimate"]
+
+    def test_verification_lag_title(self):
+        rows = {r["label"]: r for r in _verification_side_kv({"lagTimeSeconds": 75})}
+        assert rows["Lag time"]["value"] == "1m 15s"
+        assert rows["Lag time"]["title"] == "75 seconds"
+        assert rows["Lag time"]["highLag"] is True
+
+    def test_lag_time_not_highlighted_at_one_minute(self):
+        metrics = _build_progress_metrics({}, 60)
+        by_label = {m["label"]: m for m in metrics}
+        assert "highLag" not in by_label["Lag time"]
+
+    def test_lag_time_highlighted_over_one_minute(self):
+        metrics = _build_progress_metrics({}, 61)
+        by_label = {m["label"]: m for m in metrics}
+        assert by_label["Lag time"]["highLag"] is True
 
     def test_build_direction_from_progress(self):
         progress = {
@@ -214,6 +271,63 @@ class TestBuildHelpers:
         card = _build_direction(progress)
         assert card["source"]["address"] == "src:27017"
         assert card["destination"]["ping"] == "10 ms"
+
+
+class TestCollectionsFinishedLabel:
+    def test_label_from_progress_index_building(self):
+        label = _build_collections_finished_label(
+            progress={
+                "indexBuilding": {
+                    "collectionsFinished": 1,
+                    "collectionsTotal": 4,
+                }
+            },
+            progress_available=True,
+        )
+        assert label == "Collections Copied: 1 of 4"
+
+    def test_sync_card_includes_collections_finished_label(self):
+        sync = _build_sync_card(
+            progress={
+                "info": "collection copy",
+                "state": "RUNNING",
+                "collectionCopy": {
+                    "estimatedCopiedBytes": 50,
+                    "estimatedTotalBytes": 100,
+                },
+                "indexBuilding": {
+                    "collectionsFinished": 2,
+                    "collectionsTotal": 5,
+                    "indexesBuilt": 1,
+                    "totalIndexesToBuild": 10,
+                },
+            },
+            metadata={"partitionsCopied": 25, "partitionsTotal": 100},
+            progress_available=True,
+        )
+        assert sync["collectionsFinishedLabel"] == "Collections Copied: 2 of 5"
+        assert sync["copyPercent"] == 50.0
+
+    def test_sync_card_copy_percent_from_bytes_not_partitions(self):
+        sync = _build_sync_card(
+            progress={
+                "info": "collection copy",
+                "state": "RUNNING",
+                "collectionCopy": {
+                    "estimatedCopiedBytes": 90,
+                    "estimatedTotalBytes": 100,
+                },
+            },
+            metadata={"partitionsCopied": 10, "partitionsTotal": 200},
+            progress_available=True,
+        )
+        assert sync["copyPercent"] == 90.0
+
+    def test_index_building_card_includes_collections_finished_metric(self):
+        card = _build_index_building_card(1, 10, 2, 5)
+        labels = [metric["label"] for metric in card["metrics"]]
+        assert labels == ["Indexes built", "Collections finished building indexes"]
+        assert card["metrics"][1]["value"] == "2 / 5"
 
 
 class TestProgressMonitorNoConfig:

--- a/migration/mongosync_insights/tests/test_live_monitoring.py
+++ b/migration/mongosync_insights/tests/test_live_monitoring.py
@@ -11,7 +11,7 @@ from lib.app_config import (
 )
 from lib.live_monitoring import (
     ProgressFetchError,
-    _build_collections_finished_label,
+    _build_collections_copied_label,
     _build_db_only_metrics,
     _build_direction,
     _build_index_building_card,
@@ -273,20 +273,27 @@ class TestBuildHelpers:
         assert card["destination"]["ping"] == "10 ms"
 
 
-class TestCollectionsFinishedLabel:
-    def test_label_from_progress_index_building(self):
-        label = _build_collections_finished_label(
+class TestCollectionsCopiedLabel:
+    def test_prefers_atlas_live_migrate_metrics_from_progress(self):
+        label = _build_collections_copied_label(
+            metadata={"collectionsCopied": 1, "collectionsTotal": 4},
             progress={
-                "indexBuilding": {
-                    "collectionsFinished": 1,
-                    "collectionsTotal": 4,
+                "atlasLiveMigrateMetrics": {
+                    "initialNumCollectionsCopied": 267,
+                    "initialNumCollectionsTotal": 273,
                 }
             },
-            progress_available=True,
         )
-        assert label == "Collections Copied: 1 of 4"
+        assert label == "Collections copied: 267 of 273"
 
-    def test_sync_card_includes_collections_finished_label(self):
+    def test_falls_back_to_metadata_without_atlas_metrics(self):
+        label = _build_collections_copied_label(
+            metadata={"collectionsCopied": 10, "collectionsTotal": 20},
+            progress={"info": "collection copy"},
+        )
+        assert label == "Collections copied: 10 of 20"
+
+    def test_sync_card_uses_atlas_collection_totals(self):
         sync = _build_sync_card(
             progress={
                 "info": "collection copy",
@@ -295,20 +302,24 @@ class TestCollectionsFinishedLabel:
                     "estimatedCopiedBytes": 50,
                     "estimatedTotalBytes": 100,
                 },
+                "atlasLiveMigrateMetrics": {
+                    "initialNumCollectionsCopied": 267,
+                    "initialNumCollectionsTotal": 273,
+                },
                 "indexBuilding": {
                     "collectionsFinished": 2,
-                    "collectionsTotal": 5,
-                    "indexesBuilt": 1,
-                    "totalIndexesToBuild": 10,
+                    "collectionsTotal": 21,
+                    "indexesBuilt": 7,
+                    "totalIndexesToBuild": 37,
                 },
             },
-            metadata={"partitionsCopied": 25, "partitionsTotal": 100},
+            metadata={"partitionsCopied": 2601, "partitionsTotal": 2601},
             progress_available=True,
         )
-        assert sync["collectionsFinishedLabel"] == "Collections Copied: 2 of 5"
-        assert sync["copyPercent"] == 50.0
+        assert sync["collectionsCopiedLabel"] == "Collections copied: 267 of 273"
 
-    def test_sync_card_copy_percent_from_bytes_not_partitions(self):
+
+    def test_sync_card_copy_percent_from_bytes_not_collections(self):
         sync = _build_sync_card(
             progress={
                 "info": "collection copy",
@@ -317,12 +328,19 @@ class TestCollectionsFinishedLabel:
                     "estimatedCopiedBytes": 90,
                     "estimatedTotalBytes": 100,
                 },
+                "atlasLiveMigrateMetrics": {
+                    "initialNumCollectionsCopied": 267,
+                    "initialNumCollectionsTotal": 273,
+                },
             },
             metadata={"partitionsCopied": 10, "partitionsTotal": 200},
             progress_available=True,
         )
         assert sync["copyPercent"] == 90.0
+        assert sync["collectionsCopiedLabel"] == "Collections copied: 267 of 273"
 
+
+class TestIndexBuildingCard:
     def test_index_building_card_includes_collections_finished_metric(self):
         card = _build_index_building_card(1, 10, 2, 5)
         labels = [metric["label"] for metric in card["metrics"]]

--- a/migration/mongosync_insights/tests/test_log_summary.py
+++ b/migration/mongosync_insights/tests/test_log_summary.py
@@ -1,0 +1,458 @@
+"""Tests for Log Analyzer Summary tab payload built from mongosync logs."""
+import json
+
+from lib.logs_metrics import _merge_phase_events
+from lib.log_summary import (
+    build_log_metadata,
+    build_log_summary_payload,
+    extract_latest_progress,
+    extract_mongosync_version,
+    format_log_timestamp,
+    merge_replication_into_progress,
+    merge_state_transitions_into_progress,
+    natural_order_rows_from_log,
+    phase_transition_rows_from_events,
+)
+
+
+def _sent_response(time, progress, uri="/api/v1/progress"):
+    return {
+        "time": time,
+        "uri": uri,
+        "body": json.dumps({"progress": progress}),
+    }
+
+
+class TestExtractLatestProgress:
+    def test_returns_last_progress_body(self):
+        responses = [
+            _sent_response("2026-01-01T10:00:00.000Z", {"state": "RUNNING", "canCommit": False}),
+            _sent_response("2026-01-01T11:00:00.000Z", {"state": "RUNNING", "canCommit": True}),
+        ]
+        progress, ts = extract_latest_progress(responses)
+        assert progress["canCommit"] is True
+        assert ts.startswith("2026-01-01T11:00:00")
+
+    def test_skips_invalid_json_and_keeps_previous(self):
+        responses = [
+            _sent_response("2026-01-01T10:00:00.000Z", {"state": "RUNNING"}),
+            {"time": "2026-01-01T10:30:00.000Z", "body": "not-json"},
+        ]
+        progress, ts = extract_latest_progress(responses)
+        assert progress["state"] == "RUNNING"
+        assert ts.startswith("2026-01-01T10:00:00")
+
+    def test_skips_bodies_without_progress(self):
+        responses = [
+            {"time": "2026-01-01T10:00:00.000Z", "body": json.dumps({"ok": 1})},
+            _sent_response("2026-01-01T10:01:00.000Z", {"state": "PAUSED"}),
+        ]
+        progress, _ts = extract_latest_progress(responses)
+        assert progress["state"] == "PAUSED"
+
+    def test_empty_returns_none(self):
+        assert extract_latest_progress([]) == (None, None)
+        assert extract_latest_progress(None) == (None, None)
+
+
+class TestFormatLogTimestamp:
+    def test_strips_fraction_and_z(self):
+        assert format_log_timestamp("2026-01-01T12:00:00.123456Z") == "2026-01-01 12:00:00"
+
+    def test_empty(self):
+        assert format_log_timestamp(None) is None
+        assert format_log_timestamp("") is None
+
+
+class TestPhaseAndNaturalOrder:
+    def test_phase_rows_capitalize_and_format_time(self):
+        rows = phase_transition_rows_from_events(
+            [("2026-01-01T10:00:00.000Z", "collection copy")]
+        )
+        assert rows == [
+            {"phase": "Collection copy", "startedAt": "2026-01-01 10:00:00"}
+        ]
+
+    def test_natural_order_groups_by_database(self):
+        rows = natural_order_rows_from_log(
+            [
+                {"database": "db1", "collection": "c1"},
+                {"database": "db1", "collection": "c2"},
+                {"database": "db2", "collection": "x"},
+            ]
+        )
+        by_db = {r["database"]: r["collections"] for r in rows}
+        assert by_db["db1"] == "c1, c2"
+        assert by_db["db2"] == "x"
+
+    def test_natural_order_empty(self):
+        assert natural_order_rows_from_log([]) is None
+        assert natural_order_rows_from_log(None) is None
+
+
+class TestMergeReplicationIntoProgress:
+    def test_fills_missing_lag_and_events(self):
+        progress = {"state": "RUNNING"}
+        replication = [
+            {"lagTimeSeconds": 12, "totalEventsApplied": 100, "estimatedOplogTimeRemaining": "30 minutes"}
+        ]
+        merged = merge_replication_into_progress(progress, replication)
+        assert merged["lagTimeSeconds"] == 12
+        assert merged["totalEventsApplied"] == 100
+        assert merged["estimatedOplogTimeRemaining"] == "30 minutes"
+
+    def test_does_not_overwrite_progress_values(self):
+        progress = {"lagTimeSeconds": 5, "totalEventsApplied": 1}
+        replication = [{"lagTimeSeconds": 99, "totalEventsApplied": 99}]
+        merged = merge_replication_into_progress(progress, replication)
+        assert merged["lagTimeSeconds"] == 5
+        assert merged["totalEventsApplied"] == 1
+
+
+class TestBuildLogMetadata:
+    def test_start_options_and_filters(self):
+        metadata = build_log_metadata(
+            phase_events=[
+                ("2026-01-01T10:00:00.000Z", "initializing collections and indexes"),
+                ("2026-01-01T11:00:00.000Z", "commit handler called"),
+            ],
+            start_options=[
+                {
+                    "reversible": True,
+                    "enableUserWriteBlocking": "destinationOnly",
+                    "buildIndexes": "afterDataCopy",
+                    "verification": {"enabled": False},
+                    "includeNamespaces": [{"database": "sales", "collections": ["orders"]}],
+                    "excludeNamespaces": [{"database": "tmp", "collections": ["scratch"]}],
+                }
+            ],
+            natural_order_items=[{"database": "sales", "collection": "orders"}],
+            partitions_copied=10,
+            partitions_total=20,
+        )
+        assert metadata["start"] == "2026-01-01 10:00:00"
+        assert metadata["finish"] == "2026-01-01 11:00:00"
+        assert metadata["reversible"] == "True"
+        assert metadata["writeBlockingMode"] == "Destination Only"
+        assert metadata["buildIndexes"] == "After Data Copy"
+        assert metadata["verificationModeRaw"] == "disabled"
+        assert metadata["namespaceFilterActive"] is True
+        assert metadata["partitionsCopied"] == 10
+        assert metadata["naturalOrderRows"][0]["database"] == "sales"
+
+    def test_boolean_write_blocking_true(self):
+        metadata = build_log_metadata(
+            start_options=[{"enableUserWriteBlocking": True}]
+        )
+        assert metadata["writeBlockingMode"] == "Source and Destination"
+
+    def test_write_blocking_default_from_hidden_flags(self):
+        metadata = build_log_metadata(
+            hidden_flags=[{"other": {"disableWriteBlocking": False}}]
+        )
+        assert metadata["writeBlockingMode"] == "Default"
+
+    def test_write_blocking_disabled_from_hidden_flags(self):
+        metadata = build_log_metadata(
+            hidden_flags=[{"other": {"disableWriteBlocking": True}}]
+        )
+        assert metadata["writeBlockingMode"] == "Disabled"
+
+    def test_hidden_flags_override_start_write_blocking(self):
+        metadata = build_log_metadata(
+            start_options=[{"enableUserWriteBlocking": "destinationOnly"}],
+            hidden_flags=[{"other": {"disableWriteBlocking": False}}],
+        )
+        assert metadata["writeBlockingMode"] == "Default"
+
+    def test_build_indexes_null_from_start_handler(self):
+        metadata = build_log_metadata(
+            start_handler_parameters=[{"BuildIndexes": None}]
+        )
+        assert metadata["buildIndexesRaw"] == "afterDataCopy"
+        assert metadata["buildIndexes"] == "After Data Copy"
+
+    def test_build_indexes_explicit_from_start_handler(self):
+        metadata = build_log_metadata(
+            start_handler_parameters=[{"BuildIndexes": "never"}]
+        )
+        assert metadata["buildIndexesRaw"] == "never"
+        assert metadata["buildIndexes"] == "Never"
+
+    def test_start_handler_overrides_start_options_build_indexes(self):
+        metadata = build_log_metadata(
+            start_options=[{"buildIndexes": "beforeDataCopy"}],
+            start_handler_parameters=[{"BuildIndexes": None}],
+        )
+        assert metadata["buildIndexes"] == "After Data Copy"
+
+    def test_detect_random_id_null_from_start_handler(self):
+        metadata = build_log_metadata(
+            start_handler_parameters=[{"DetectRandomId": None}]
+        )
+        assert metadata["detectRandomId"] == "True"
+
+    def test_detect_random_id_true_from_start_handler(self):
+        metadata = build_log_metadata(
+            start_handler_parameters=[{"DetectRandomId": True}]
+        )
+        assert metadata["detectRandomId"] == "True"
+
+    def test_detect_random_id_false_from_start_handler(self):
+        metadata = build_log_metadata(
+            start_handler_parameters=[{"DetectRandomId": False}]
+        )
+        assert metadata["detectRandomId"] == "False"
+
+    def test_start_handler_overrides_start_options_detect_random_id(self):
+        metadata = build_log_metadata(
+            start_options=[{"detectRandomId": False}],
+            start_handler_parameters=[{"DetectRandomId": None}],
+        )
+        assert metadata["detectRandomId"] == "True"
+
+    def test_reversible_true_from_start_handler(self):
+        metadata = build_log_metadata(
+            start_handler_parameters=[{"Reversible": True}]
+        )
+        assert metadata["reversible"] == "True"
+
+    def test_reversible_false_from_start_handler(self):
+        metadata = build_log_metadata(
+            start_handler_parameters=[{"Reversible": False}]
+        )
+        assert metadata["reversible"] == "False"
+
+    def test_start_handler_overrides_start_options_reversible(self):
+        metadata = build_log_metadata(
+            start_options=[{"reversible": True}],
+            start_handler_parameters=[{"Reversible": False}],
+        )
+        assert metadata["reversible"] == "False"
+
+    def test_finish_from_committed_state_transition(self):
+        metadata = build_log_metadata(
+            state_transitions=[
+                {
+                    "time": "2026-07-09T04:27:29.065111Z",
+                    "newState": "COMMITTED",
+                    "message": "Transitioning the state.",
+                }
+            ]
+        )
+        assert metadata["finish"] == "2026-07-09 04:27:29"
+
+    def test_committed_state_overrides_phase_finish(self):
+        metadata = build_log_metadata(
+            phase_events=[("2026-01-01T11:00:00.000Z", "commit handler called")],
+            state_transitions=[
+                {
+                    "time": "2026-07-09T04:27:29.065111Z",
+                    "newState": "COMMITTED",
+                }
+            ],
+        )
+        assert metadata["finish"] == "2026-07-09 04:27:29"
+
+    def test_sync_phase_from_progress_info(self):
+        metadata = build_log_metadata(
+            progress={"info": "change event application", "state": "RUNNING"}
+        )
+        assert metadata["syncPhase"] == "change event application"
+        assert metadata["phase"] == "Change event application"
+
+    def test_committed_state_overrides_stale_progress_info(self):
+        progress = {
+            "state": "COMMITTING",
+            "info": "waiting for index constraint enablement at the end of commit",
+        }
+        phase_events = [
+            (
+                "2026-04-20T01:18:47.641305",
+                "waiting for index constraint enablement at the end of commit",
+            ),
+            ("2026-04-20T01:19:25.139116", "commit completed"),
+        ]
+        state_transitions = [
+            {
+                "time": "2026-04-20T01:19:25.139112Z",
+                "newState": "COMMITTED",
+                "message": "Transitioning the state.",
+            }
+        ]
+        merged = merge_state_transitions_into_progress(
+            progress, state_transitions, phase_events
+        )
+        assert merged["state"] == "COMMITTED"
+        assert merged["info"] == "commit completed"
+
+    def test_summary_payload_shows_committed_phase_after_last_progress(self):
+        payload = build_log_summary_payload(
+            progress={
+                "state": "COMMITTING",
+                "info": "waiting for index constraint enablement at the end of commit",
+            },
+            progress_time="2026-04-20T01:19:04.593714Z",
+            phase_events=[
+                (
+                    "2026-04-20T01:18:47.641305",
+                    "waiting for index constraint enablement at the end of commit",
+                ),
+                ("2026-04-20T01:19:25.139116", "commit completed"),
+            ],
+            state_transitions=[
+                {
+                    "time": "2026-04-20T01:19:25.139112Z",
+                    "newState": "COMMITTED",
+                }
+            ],
+        )
+        display = payload["display"]
+        assert display["state"] == "COMMITTED"
+        assert display["sync"]["phase"] == "commit completed"
+
+
+class TestExtractMongosyncVersion:
+    def test_returns_first_version(self):
+        lines = [
+            {"message": "Version info", "version": "1.9.0"},
+            {"message": "Version info", "version": "2.0.0"},
+        ]
+        assert extract_mongosync_version(lines) == "1.9.0"
+
+    def test_missing_returns_none(self):
+        assert extract_mongosync_version([]) is None
+        assert extract_mongosync_version([{"message": "Version info"}]) is None
+
+
+class TestBuildLogSummaryPayload:
+    def test_progress_payload_matches_live_monitor_shape(self):
+        progress = {
+            "state": "RUNNING",
+            "info": "collection copy",
+            "canCommit": False,
+            "canWrite": False,
+            "lagTimeSeconds": 8,
+            "totalEventsApplied": 42,
+            "collectionCopy": {
+                "estimatedCopiedBytes": 50,
+                "estimatedTotalBytes": 100,
+            },
+            "directionMapping": {
+                "Source": "src.example.com:27017",
+                "Destination": "dst.example.com:27017",
+            },
+            "indexBuilding": {
+                "indexesBuilt": 1,
+                "totalIndexesToBuild": 4,
+                "collectionsFinished": 0,
+                "collectionsTotal": 2,
+            },
+            "verification": {
+                "source": {"phase": "in progress", "hashedDocumentCount": 1, "estimatedDocumentCount": 10},
+                "destination": {"phase": "in progress", "hashedDocumentCount": 1, "estimatedDocumentCount": 10},
+            },
+            "warnings": ["example warning"],
+        }
+        payload = build_log_summary_payload(
+            progress=progress,
+            progress_time="2026-01-01T12:00:00.000Z",
+            phase_events=[("2026-01-01T10:00:00.000Z", "collection copy")],
+            partitions_copied=50,
+            partitions_total=100,
+        )
+        assert payload["error"] is None
+        assert payload["pageTitle"] == "Summary"
+        assert "latest /progress" in payload["pageSubtitle"]
+        assert payload["warnings"] == ["example warning"]
+        display = payload["display"]
+        assert display["state"] == "RUNNING"
+        assert display["sync"]["phase"] == "collection copy"
+        assert display["sync"]["copyPercent"] == 50.0
+        assert display["direction"]["source"]["address"] == "src.example.com:27017"
+        assert display["indexBuilding"]["built"] == 1
+        index_metrics = {
+            m["label"]: m["value"] for m in display["indexBuilding"]["metrics"]
+        }
+        assert index_metrics["Collections finished building indexes"] == "0 / 2"
+        assert display["verification"]["title"] == "Embedded Verifier"
+        badges = {b["id"]: b for b in payload["dataSources"]["badges"]}
+        assert badges["progress"]["label"] == "Latest /progress"
+        assert badges["progress"]["status"] == "active"
+
+    def test_summary_includes_mongosync_version(self):
+        payload = build_log_summary_payload(
+            progress={"state": "RUNNING", "info": "collection copy"},
+            version_info_lines=[{"message": "Version info", "version": "1.18.0"}],
+        )
+        sync = payload["display"]["sync"]
+        assert sync["showMongosyncVersion"] is True
+        assert sync["mongosyncVersion"] == "1.18.0"
+
+    def test_summary_missing_version_shows_hover_title(self):
+        payload = build_log_summary_payload(
+            progress={"state": "RUNNING", "info": "collection copy"},
+        )
+        sync = payload["display"]["sync"]
+        assert sync["showMongosyncVersion"] is True
+        assert "mongosyncVersion" not in sync
+        assert "Missing initial log file for version capture.\n" in sync["mongosyncVersionMissingTitle"]
+        assert "Upload all rotated mongosync files for full analysis" in sync["mongosyncVersionMissingTitle"]
+
+    def test_metadata_only_when_no_progress(self):
+        payload = build_log_summary_payload(
+            phase_events=[("2026-01-01T10:00:00.000Z", "collection copy")],
+            start_options=[{"reversible": False, "buildIndexes": "never"}],
+        )
+        assert payload["error"] is None
+        assert payload["display"]["sync"]["phaseStartTimes"]["rows"][0]["phase"] == "Collection copy"
+        assert payload["display"]["sync"]["metadataMetrics"]
+        badges = payload["dataSources"]["badges"]
+        assert len(badges) == 1
+        assert badges[0]["id"] == "metadata"
+        assert badges[0]["label"] == "Log events"
+
+    def test_replication_fallback_fills_lag(self):
+        payload = build_log_summary_payload(
+            replication_lines=[
+                {
+                    "time": "2026-01-01T10:01:00.000Z",
+                    "lagTimeSeconds": 15,
+                    "totalEventsApplied": 9,
+                }
+            ],
+            phase_events=[("2026-01-01T10:00:00.000Z", "change event application")],
+        )
+        metrics = {m["label"]: m["value"] for m in payload["display"]["sync"]["metrics"]}
+        assert metrics["Lag time"] == "15s"
+        assert metrics["Events applied"] == "9"
+        assert payload["display"]["sync"]["phase"] == "change event application"
+
+    def test_phase_rows_from_messages_with_trailing_period(self):
+        payload = build_log_summary_payload(
+            phase_events=_merge_phase_events(
+                [
+                    {
+                        "time": "2026-07-20T17:53:11.775615Z",
+                        "message": "Starting collection copy phase.",
+                    },
+                    {
+                        "time": "2026-07-21T03:49:22.808282Z",
+                        "message": "Starting change event application phase.",
+                    },
+                ],
+                [],
+            )
+        )
+        rows = {
+            row["phase"]: row["startedAt"]
+            for row in payload["display"]["sync"]["phaseStartTimes"]["rows"]
+        }
+        assert rows["Collection copy"] == "2026-07-20 17:53:11"
+        assert rows["Change event application"] == "2026-07-21 03:49:22"
+
+    def test_empty_payload(self):
+        payload = build_log_summary_payload()
+        assert payload["display"] is None
+        assert payload["error"]
+        assert payload["pageTitle"] == "Summary"

--- a/migration/mongosync_insights/tests/test_log_summary.py
+++ b/migration/mongosync_insights/tests/test_log_summary.py
@@ -3,13 +3,20 @@ import json
 
 from lib.logs_metrics import _merge_phase_events
 from lib.log_summary import (
+    backfill_commit_events_applied,
     build_log_metadata,
     build_log_summary_payload,
     extract_latest_progress,
     extract_mongosync_version,
     format_log_timestamp,
+    merge_index_building_into_progress,
+    merge_phase_events_into_progress,
     merge_replication_into_progress,
+    merge_events_applied_into_progress,
+    merge_verification_into_progress,
     merge_state_transitions_into_progress,
+    build_summary_migration_state,
+    SummaryMigrationState,
     natural_order_rows_from_log,
     phase_transition_rows_from_events,
 )
@@ -91,22 +98,376 @@ class TestPhaseAndNaturalOrder:
 
 
 class TestMergeReplicationIntoProgress:
-    def test_fills_missing_lag_and_events(self):
+    def test_fills_missing_lag_and_oplog(self):
         progress = {"state": "RUNNING"}
         replication = [
             {"lagTimeSeconds": 12, "totalEventsApplied": 100, "estimatedOplogTimeRemaining": "30 minutes"}
         ]
         merged = merge_replication_into_progress(progress, replication)
         assert merged["lagTimeSeconds"] == 12
-        assert merged["totalEventsApplied"] == 100
         assert merged["estimatedOplogTimeRemaining"] == "30 minutes"
+        assert "totalEventsApplied" not in merged
 
-    def test_does_not_overwrite_progress_values(self):
+    def test_does_not_overwrite_progress_lag(self):
         progress = {"lagTimeSeconds": 5, "totalEventsApplied": 1}
         replication = [{"lagTimeSeconds": 99, "totalEventsApplied": 99}]
         merged = merge_replication_into_progress(progress, replication)
         assert merged["lagTimeSeconds"] == 5
         assert merged["totalEventsApplied"] == 1
+
+
+class TestMergeEventsAppliedIntoProgress:
+    def test_fills_missing_events(self):
+        progress = {"state": "RUNNING"}
+        replication = [{"totalEventsApplied": 100}]
+        merged = merge_events_applied_into_progress(
+            progress, replication_lines=replication
+        )
+        assert merged["totalEventsApplied"] == 100
+
+    def test_backfills_zero_progress_events_from_replication(self):
+        progress = {"info": "change event application", "totalEventsApplied": 0}
+        replication = [
+            {"totalEventsApplied": 100},
+            {"totalEventsApplied": 120},
+            {"totalEventsApplied": 0},
+        ]
+        merged = merge_events_applied_into_progress(
+            progress, replication_lines=replication
+        )
+        assert merged["totalEventsApplied"] == 120
+
+
+class TestSummaryMigrationState:
+    def test_tracks_latest_phase_by_timestamp(self):
+        state = SummaryMigrationState()
+        state.note_progress(
+            {"state": "RUNNING", "info": "collection copy"},
+            "2026-04-20T15:51:01.869718Z",
+        )
+        state.note_phase(
+            "change event application",
+            "2026-04-20T15:51:16.174795Z",
+        )
+        progress = state.to_progress()
+        assert progress["info"] == "change event application"
+
+    def test_build_summary_migration_state_replays_log_events(self):
+        state = build_summary_migration_state(
+            sent_responses=[
+                _sent_response(
+                    "2026-04-20T15:51:01.869718Z",
+                    {"state": "RUNNING", "info": "collection copy"},
+                )
+            ],
+            phase_events=[
+                ("2026-04-20T15:51:16.174795Z", "change event application"),
+            ],
+            index_creation_lines=[
+                {
+                    "time": "2026-04-20T15:52:00.000000Z",
+                    "indexCreationProgress": {
+                        "totalIndexesBuilt": 7,
+                        "totalIndexesToBuild": 37,
+                        "finishedCollections": 2,
+                        "totalCollections": 21,
+                    },
+                }
+            ],
+        )
+        progress = state.to_progress()
+        assert progress["info"] == "change event application"
+        assert progress["indexBuilding"]["indexesBuilt"] == 7
+
+
+class TestMergePhaseEventsIntoProgress:
+    def test_overlays_newer_phase_when_progress_is_stale(self):
+        progress = {"state": "RUNNING", "info": "collection copy"}
+        phase_events = [
+            ("2026-04-20T15:20:49.967653", "collection copy"),
+            ("2026-04-20T15:51:16.174795", "change event application"),
+        ]
+        merged = merge_phase_events_into_progress(
+            progress,
+            phase_events,
+            progress_time="2026-04-20T15:51:01.869718Z",
+        )
+        assert merged["info"] == "change event application"
+
+    def test_does_not_override_when_progress_is_newer(self):
+        progress = {"state": "RUNNING", "info": "waiting for commit to complete"}
+        phase_events = [
+            ("2026-04-20T19:41:45.401715", "change event application"),
+        ]
+        merged = merge_phase_events_into_progress(
+            progress,
+            phase_events,
+            progress_time="2026-04-20T19:42:35.726345Z",
+        )
+        assert merged["info"] == "waiting for commit to complete"
+
+    def test_does_not_override_committed_state(self):
+        progress = {"state": "COMMITTED", "info": "commit completed"}
+        phase_events = [("2026-04-20T15:51:16.174795", "change event application")]
+        merged = merge_phase_events_into_progress(
+            progress,
+            phase_events,
+            progress_time="2026-04-20T15:51:01.869718Z",
+        )
+        assert merged["info"] == "commit completed"
+
+
+class TestMergeIndexBuildingIntoProgress:
+    def test_backfills_from_last_sent_response(self):
+        progress = {"state": "COMMITTING", "info": "waiting for commit to complete"}
+        sent_responses = [
+            _sent_response(
+                "2026-04-20T19:41:45.401715Z",
+                {
+                    "state": "RUNNING",
+                    "info": "change event application",
+                    "indexBuilding": {
+                        "indexesBuilt": 37,
+                        "totalIndexesToBuild": 37,
+                        "collectionsFinished": 21,
+                        "collectionsTotal": 21,
+                    },
+                },
+            ),
+            _sent_response(
+                "2026-04-20T19:42:35.726345Z",
+                {"state": "COMMITTING", "info": "waiting for commit to complete"},
+            ),
+        ]
+        merged = merge_index_building_into_progress(
+            progress, sent_responses=sent_responses
+        )
+        assert merged["indexBuilding"] == {
+            "indexesBuilt": 37,
+            "totalIndexesToBuild": 37,
+            "collectionsFinished": 21,
+            "collectionsTotal": 21,
+        }
+
+    def test_backfills_from_index_creation_progress(self):
+        progress = {"state": "COMMITTING"}
+        merged = merge_index_building_into_progress(
+            progress,
+            index_creation_lines=[
+                {
+                    "message": "Index creation progress.",
+                    "indexCreationProgress": {
+                        "totalIndexesBuilt": 10,
+                        "totalIndexesToBuild": 12,
+                        "finishedCollections": 3,
+                        "totalCollections": 4,
+                    },
+                }
+            ],
+        )
+        assert merged["indexBuilding"]["indexesBuilt"] == 10
+        assert merged["indexBuilding"]["totalIndexesToBuild"] == 12
+        assert merged["indexBuilding"]["collectionsTotal"] == 4
+
+    def test_summary_shows_in_progress_index_build_during_collection_copy(self):
+        payload = build_log_summary_payload(
+            progress={
+                "state": "RUNNING",
+                "info": "collection copy",
+            },
+            start_options=[{"buildIndexes": "afterDataCopy"}],
+            index_creation_lines=[
+                {
+                    "message": "Index creation progress.",
+                    "indexCreationProgress": {
+                        "totalIndexesBuilt": 7,
+                        "totalIndexesToBuild": 37,
+                        "finishedCollections": 2,
+                        "totalCollections": 21,
+                    },
+                }
+            ],
+        )
+        idx = payload["display"]["indexBuilding"]
+        assert idx is not None
+        assert idx.get("mode") != "info"
+        assert idx["built"] == 7
+        assert idx["total"] == 37
+        by_label = {m["label"]: m["value"] for m in idx["metrics"]}
+        assert by_label["Collections finished building indexes"] == "2 / 21"
+
+    def test_summary_collections_copied_from_atlas_live_migrate_metrics(self):
+        payload = build_log_summary_payload(
+            progress={
+                "state": "RUNNING",
+                "info": "collection copy",
+                "atlasLiveMigrateMetrics": {
+                    "initialNumCollectionsCopied": 267,
+                    "initialNumCollectionsTotal": 273,
+                },
+                "collectionCopy": {
+                    "estimatedCopiedBytes": 100,
+                    "estimatedTotalBytes": 200,
+                },
+            },
+            partitions_copied=2601,
+            partitions_total=2601,
+            index_creation_lines=[
+                {
+                    "indexCreationProgress": {
+                        "totalIndexesBuilt": 7,
+                        "totalIndexesToBuild": 37,
+                        "finishedCollections": 2,
+                        "totalCollections": 21,
+                    },
+                }
+            ],
+        )
+        sync = payload["display"]["sync"]
+        assert sync["collectionsCopiedLabel"] == "Collections copied: 267 of 273"
+        assert sync["partitionsCopiedLabel"] == "Partitions copied: 2,601 of 2,601"
+        assert sync["copyPercent"] == 50.0
+
+    def test_build_log_metadata_uses_atlas_collection_totals(self):
+        metadata = build_log_metadata(
+            progress={
+                "state": "RUNNING",
+                "info": "collection copy",
+                "atlasLiveMigrateMetrics": {
+                    "initialNumCollectionsCopied": 12,
+                    "initialNumCollectionsTotal": 15,
+                },
+            },
+        )
+        assert metadata["collectionsCopied"] == 12
+        assert metadata["collectionsTotal"] == 15
+
+    def test_summary_payload_shows_cea_when_phase_event_is_newer_than_progress(self):
+        payload = build_log_summary_payload(
+            progress={"state": "RUNNING", "info": "collection copy"},
+            progress_time="2026-04-20T15:51:01.869718Z",
+            phase_events=[
+                ("2026-04-20T15:20:49.967653", "collection copy"),
+                ("2026-04-20T15:51:16.174795", "change event application"),
+            ],
+        )
+        assert payload["display"]["sync"]["phase"] == "change event application"
+
+    def test_prefers_sent_response_over_index_creation_progress(self):
+        progress = {"state": "COMMITTING"}
+        merged = merge_index_building_into_progress(
+            progress,
+            sent_responses=[
+                _sent_response(
+                    "2026-04-20T19:41:45.401715Z",
+                    {
+                        "indexBuilding": {
+                            "indexesBuilt": 5,
+                            "totalIndexesToBuild": 5,
+                            "collectionsFinished": 2,
+                            "collectionsTotal": 2,
+                        }
+                    },
+                )
+            ],
+            index_creation_lines=[
+                {
+                    "indexCreationProgress": {
+                        "totalIndexesBuilt": 99,
+                        "totalIndexesToBuild": 99,
+                        "finishedCollections": 9,
+                        "totalCollections": 9,
+                    }
+                }
+            ],
+        )
+        assert merged["indexBuilding"]["indexesBuilt"] == 5
+
+
+class TestMergeVerificationIntoProgress:
+    def test_backfills_when_latest_progress_omits_verification(self):
+        verification = {
+            "source": {"phase": "stream hashing", "scannedCollectionCount": 10},
+            "destination": {"phase": "stream hashing", "scannedCollectionCount": 9},
+        }
+        merged = merge_verification_into_progress(
+            {"state": "RUNNING", "info": "change event application"},
+            sent_responses=[
+                _sent_response(
+                    "2026-04-20T15:51:00.000Z",
+                    {"state": "RUNNING", "info": "collection copy"},
+                ),
+                _sent_response(
+                    "2026-04-20T16:00:00.000Z",
+                    {
+                        "state": "RUNNING",
+                        "info": "change event application",
+                        "verification": verification,
+                    },
+                ),
+                _sent_response(
+                    "2026-04-20T16:30:00.000Z",
+                    {"state": "RUNNING", "info": "change event application"},
+                ),
+            ],
+        )
+        assert merged["verification"] == verification
+
+    def test_summary_shows_verifier_progress_during_cea(self):
+        verification = {
+            "source": {
+                "phase": "initial hashing",
+                "scannedCollectionCount": 5,
+                "totalCollectionCount": 10,
+            },
+            "destination": {
+                "phase": "initial hashing",
+                "scannedCollectionCount": 4,
+                "totalCollectionCount": 10,
+            },
+        }
+        payload = build_log_summary_payload(
+            sent_responses=[
+                _sent_response(
+                    "2026-04-20T16:00:00.000Z",
+                    {
+                        "state": "RUNNING",
+                        "info": "change event application",
+                        "verification": verification,
+                    },
+                ),
+                _sent_response(
+                    "2026-04-20T16:30:00.000Z",
+                    {"state": "RUNNING", "info": "change event application"},
+                ),
+            ],
+            start_options=[{"verification": {"enabled": True, "startAt": "cea"}}],
+            phase_events=[
+                ("2026-04-20T15:51:00.000Z", "collection copy"),
+                ("2026-04-20T16:00:00.000Z", "change event application"),
+            ],
+        )
+        card = payload["display"]["verification"]
+        assert card is not None
+        assert card.get("mode") != "info"
+        assert card["source"][1]["value"] == "5 / 10"
+
+
+class TestBackfillCommitEventsApplied:
+    def test_uses_last_positive_replication_value_on_commit_completed(self):
+        progress = {"info": "commit completed", "totalEventsApplied": 0}
+        replication = [
+            {"totalEventsApplied": 120},
+            {"totalEventsApplied": 0},
+        ]
+        merged = backfill_commit_events_applied(progress, replication)
+        assert merged["totalEventsApplied"] == 120
+
+    def test_does_not_change_non_commit_phase(self):
+        progress = {"info": "change event application", "totalEventsApplied": 0}
+        replication = [{"totalEventsApplied": 120}]
+        merged = backfill_commit_events_applied(progress, replication)
+        assert merged["totalEventsApplied"] == 0
 
 
 class TestBuildLogMetadata:
@@ -310,6 +671,76 @@ class TestBuildLogMetadata:
         display = payload["display"]
         assert display["state"] == "COMMITTED"
         assert display["sync"]["phase"] == "commit completed"
+
+    def test_summary_payload_uses_last_known_events_on_commit_completed(self):
+        payload = build_log_summary_payload(
+            progress={
+                "state": "COMMITTING",
+                "info": "waiting for index constraint enablement at the end of commit",
+                "totalEventsApplied": 0,
+            },
+            replication_lines=[
+                {"time": "2026-04-20T01:18:30.000000Z", "totalEventsApplied": 125},
+                {"time": "2026-04-20T01:19:09.000000Z", "totalEventsApplied": 0},
+            ],
+            phase_events=[
+                (
+                    "2026-04-20T01:18:47.641305",
+                    "waiting for index constraint enablement at the end of commit",
+                ),
+                ("2026-04-20T01:19:25.139116", "commit completed"),
+            ],
+            state_transitions=[
+                {
+                    "time": "2026-04-20T01:19:25.139112Z",
+                    "newState": "COMMITTED",
+                }
+            ],
+        )
+        display = payload["display"]
+        assert display["sync"]["phase"] == "commit completed"
+        by_label = {m["label"]: m["value"] for m in display["sync"]["metrics"]}
+        assert by_label["Events applied"] == "125"
+
+    def test_summary_payload_shows_index_building_when_latest_progress_omits_it(self):
+        payload = build_log_summary_payload(
+            progress={
+                "state": "COMMITTING",
+                "info": "waiting for commit to complete",
+            },
+            progress_time="2026-04-20T19:42:35.726345Z",
+            start_options=[{"buildIndexes": "afterDataCopy"}],
+            sent_responses=[
+                _sent_response(
+                    "2026-04-20T19:41:45.401715Z",
+                    {
+                        "state": "RUNNING",
+                        "info": "change event application",
+                        "indexBuilding": {
+                            "indexesBuilt": 37,
+                            "totalIndexesToBuild": 37,
+                            "collectionsFinished": 21,
+                            "collectionsTotal": 21,
+                        },
+                    },
+                ),
+                _sent_response(
+                    "2026-04-20T19:42:35.726345Z",
+                    {
+                        "state": "COMMITTING",
+                        "info": "waiting for commit to complete",
+                    },
+                ),
+            ],
+        )
+        idx = payload["display"]["indexBuilding"]
+        assert idx is not None
+        assert idx.get("mode") != "info"
+        assert idx["built"] == 37
+        assert idx["total"] == 37
+        by_label = {m["label"]: m["value"] for m in idx["metrics"]}
+        assert by_label["Indexes built"] == "37 / 37"
+        assert by_label["Collections finished building indexes"] == "21 / 21"
 
 
 class TestExtractMongosyncVersion:

--- a/migration/mongosync_insights/tests/test_logs_metrics.py
+++ b/migration/mongosync_insights/tests/test_logs_metrics.py
@@ -49,6 +49,20 @@ class TestPhaseEventFromInfo:
     def test_unknown_message_returns_none(self):
         assert _phase_event_from_info({"time": "2026-01-01T12:00:00Z", "message": "other"}) is None
 
+    @pytest.mark.parametrize(
+        "message,canonical",
+        [
+            ("Starting collection copy phase.", "collection copy"),
+            ("Starting change event application phase.", "change event application"),
+            ("Starting initializing partitions phase.", "initializing partitions"),
+        ],
+    )
+    def test_maps_info_messages_with_trailing_period(self, message, canonical):
+        obj = {"time": "2026-01-01T12:00:00.123456Z", "message": message}
+        event = _phase_event_from_info(obj)
+        assert event is not None
+        assert event[1] == canonical
+
 
 class TestPhaseEventFromInMemory:
     def test_parses_phase_update(self):
@@ -102,6 +116,23 @@ class TestMergePhaseEvents:
         api = [{"Phase": "change event application", "Ts": {"T": 1700000100}}]
         merged = _merge_phase_events([], [], api_transitions=api)
         assert merged[0][1] == "change event application"
+
+    def test_info_messages_with_trailing_period(self):
+        info = [
+            {
+                "time": "2026-07-20T17:53:11.775615Z",
+                "message": "Starting collection copy phase.",
+            },
+            {
+                "time": "2026-07-21T03:49:22.808282Z",
+                "message": "Starting change event application phase.",
+            },
+        ]
+        merged = _merge_phase_events(info, [])
+        by_phase = {label: ts for ts, label in merged}
+        assert "collection copy" in by_phase
+        assert "change event application" in by_phase
+        assert by_phase["change event application"].startswith("2026-07-21T03:49:22")
 
 
 class TestExtractProgressFlagEvents:

--- a/migration/mongosync_insights/tests/test_upload_fixtures.py
+++ b/migration/mongosync_insights/tests/test_upload_fixtures.py
@@ -29,6 +29,8 @@ class TestUploadFixtures:
                 "/logs/uploadLogs", data=data, content_type="multipart/form-data"
             )
         assert r.status_code == 200
+        assert b'id="tab-summary"' in r.data
+        assert b"Summary" in r.data
         snapshots = snapshot_store.list_snapshots()
         assert len(snapshots) >= 1
         assert snapshots[0]["line_count"] > 0

--- a/migration/mongosync_insights/tests/test_utils.py
+++ b/migration/mongosync_insights/tests/test_utils.py
@@ -8,6 +8,7 @@ from lib.utils import (
     format_count,
     format_lag_time_seconds,
     format_ratio,
+    format_seconds_title,
 )
 
 
@@ -45,6 +46,23 @@ class TestFormatLagTimeSeconds:
     )
     def test_format_lag_time_seconds(self, seconds, expected):
         assert format_lag_time_seconds(seconds) == expected
+
+
+class TestFormatSecondsTitle:
+    @pytest.mark.parametrize(
+        "seconds,expected",
+        [
+            (None, None),
+            (-5, None),
+            (0, "0 seconds"),
+            (1, "1 second"),
+            (45, "45 seconds"),
+            (90, "90 seconds"),
+            (1582, "1,582 seconds"),
+        ],
+    )
+    def test_format_seconds_title(self, seconds, expected):
+        assert format_seconds_title(seconds) == expected
 
 
 class TestFormatCount:

--- a/migration/mongosync_insights/tests/test_verification_mode.py
+++ b/migration/mongosync_insights/tests/test_verification_mode.py
@@ -102,6 +102,18 @@ class TestResolveVerificationDisplay(unittest.TestCase):
         self.assertEqual(card["mode"], "info")
         self.assertIn("CEA", card["description"])
 
+    def test_start_at_cea_in_cea_without_progress_data_returns_none(self):
+        metadata = {
+            "verificationModeRaw": "startAtCEA",
+            "syncPhase": "change event application",
+        }
+        card = _resolve_verification_display(
+            {"state": "RUNNING", "info": "change event application"},
+            metadata,
+            progress_available=True,
+        )
+        self.assertIsNone(card)
+
     def test_start_at_cea_with_progress_data(self):
         progress = {
             "verification": {


### PR DESCRIPTION
## Summary
- Add Log Analyzer **Summary** tab using the Live Migration dashboard layout from parsed mongosync logs (latest /progress sent responses, replication progress, phase events, start options).
- Introduce `SummaryMigrationState` to replay log events and backfill fields dropped from the latest `/progress` snapshot (events applied, index building, embedded verifier progress).
- **Migration Progress (Summary):** collections copied from `atlasLiveMigrateMetrics`; progress bar from `estimatedCopiedBytes` / `estimatedTotalBytes`; mongosync version on card title; UTC below phase start times; lag > 60s highlighted; Finish labeled Migration Committed.
- Fix duplicate collections-copied line; verifier card no longer shows pre-CEA placeholder once CEA has started.

## Test plan
- [ ] Upload completed Atlas Live Migrate log — Summary phase, byte bar at 100%, collections copied from Atlas metrics
- [ ] Upload in-progress log — Events applied, verifier, and index building cards populate
- [ ] Confirm Live Monitoring tab behavior unchanged except shared renderer fixes
- [ ] `pytest migration/mongosync_insights/tests/test_log_summary.py migration/mongosync_insights/tests/test_live_monitoring.py migration/mongosync_insights/tests/test_verification_mode.py`


Made with [Cursor](https://cursor.com)